### PR TITLE
Inject hooks to executor constructor.

### DIFF
--- a/hook/consul/hook.go
+++ b/hook/consul/hook.go
@@ -37,6 +37,12 @@ type Hook struct {
 	serviceInstances []instance
 }
 
+// Config is Consul hook configuration settable from environment
+type Config struct {
+	// Consul ACL Token
+	ConsulToken string `default:"" envconfig:"consul_token"`
+}
+
 // HandleEvent calls appropriate hook functions that correspond to supported
 // event types. Unsupported events are ignored.
 func (h *Hook) HandleEvent(event hook.Event) error {
@@ -206,9 +212,9 @@ func generateURL(info *mesos.HealthCheck_HTTPCheckInfo, port int) string {
 }
 
 // NewHook creates new Consul hook that is responsible for graceful Consul deregistration.
-func NewHook(token string) (hook.Hook, error) {
+func NewHook(cfg Config) (hook.Hook, error) {
 	config := api.DefaultConfig()
-	config.Token = token
+	config.Token = cfg.ConsulToken
 	client, err := api.NewClient(config)
 	if err != nil {
 		return nil, err

--- a/hook/vaas/hook.go
+++ b/hook/vaas/hook.go
@@ -31,6 +31,16 @@ type Hook struct {
 	client    Client
 }
 
+// Config is Varnish configuration settable from environment
+type Config struct {
+	// Varnish as a Service API url
+	VaasAPIHost string `default:"" envconfig:"vaas_host"`
+	// Varnish as a Service username
+	VaasAPIUsername string `default:"" envconfig:"vaas_username"`
+	// Varnish as a Service access token
+	VaasAPIKey string `default:"" envconfig:"vaas_token"`
+}
+
 // RegisterBackend adds new backend to VaaS if it does not exist.
 func (sh *Hook) RegisterBackend(taskInfo mesos.TaskInfo) error {
 	handyTaskInfo := mesosutils.TaskInfo{TaskInfo: taskInfo}
@@ -200,12 +210,12 @@ func (sh *Hook) HandleEvent(event hook.Event) error {
 }
 
 // NewHook returns new instance of Hook.
-func NewHook(apiHost string, apiUsername string, apiKey string) (*Hook, error) {
+func NewHook(cfg Config) (*Hook, error) {
 	return &Hook{
 		client: NewClient(
-			apiHost,
-			apiUsername,
-			apiKey,
+			cfg.VaasAPIHost,
+			cfg.VaasAPIUsername,
+			cfg.VaasAPIKey,
 		),
 	}, nil
 }


### PR DESCRIPTION
Move creation and configuration of hooks to main function.
This will enable users to simply replace main.go with
their own implementation to use custom hooks.
Hooks configuration is indepenedent from Executor configuration
so there is no need to keep it in Executor.