### PR TITLE
Use only Go 1.9.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.8.x
   - 1.9.x
+  - master
 
 script: make coveralls

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ as a canary.
 
 To run executor tests locally you need following tools installed:
 
-* [Go 1.8+][6]
+* [Go 1.9+][6]
 * [Make][7]
 * Linux or Docker
 


### PR DESCRIPTION
There is no need to keep backward compatibility with
old Go.