### PR TITLE
Working link to marathon-test-app.json in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Binary will be immediately available on virtual machine on following address:
 
 You can use above address to configure your Marathon application to be executed
 by your freshly build executor. An example application is available in
-[examples/marathon-test-app.json](marathon-test-app.json)
+[marathon-test-app.json](examples/marathon-test-app.json)
 
 Executor configuration can be altered via environment variables in the following way:
 ```


### PR DESCRIPTION
Without this change link points to https://github.com/allegro/mesos-executor/blob/master/marathon-test-app.json