### PR TITLE
Make health checks use public IP - if possible

### DIFF
--- a/health_checker_test.go
+++ b/health_checker_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"strconv"
 	"testing"
 	"time"
@@ -298,6 +299,20 @@ func TestIfHTTPHealthCheckFailsWhenNoServiceIsListeningOnConfiguredPort(t *testi
 	err := httpHealthCheck(check)
 
 	assert.Error(t, err)
+}
+
+func TestIfUsesPublicIPForHealthCheckAddress(t *testing.T) {
+	os.Setenv("CLOUD_PUBLIC_IP", "6.6.6.6")
+	defer os.Unsetenv("CLOUD_PUBLIC_IP")
+
+	address := HealthCheckAddress(1234)
+
+	assert.Equal(t, "6.6.6.6:1234", address)
+}
+
+func TestIfFallbacksToLoopbackIfUnableToDeterminePublicIP(t *testing.T) {
+	address := HealthCheckAddress(1234)
+	assert.Equal(t, "127.0.0.1:1234", address)
 }
 
 func buildHTTPCheck(scheme string, port uint32, path string, timeoutSeconds float64) mesos.HealthCheck {

--- a/hook/consul/hook.go
+++ b/hook/consul/hook.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/consul/api"
 	"github.com/mesos/mesos-go/api/v1/lib"
 
+	executor "github.com/allegro/mesos-executor"
 	"github.com/allegro/mesos-executor/hook"
 	"github.com/allegro/mesos-executor/mesosutils"
 	"github.com/allegro/mesos-executor/runenv"
@@ -19,7 +20,6 @@ const (
 	// See: https://github.com/allegro/marathon-consul/blob/v1.1.0/apps/app.go#L10-L11
 	consulNameLabelKey = "consul"
 	consulTagValue     = "tag"
-	serviceHost        = "127.0.0.1"
 )
 
 // instance represents a service in consul
@@ -189,8 +189,7 @@ func generateHealthCheck(mesosCheck *mesos.HealthCheck, port int) *api.AgentServ
 
 		return &check
 	} else if mesosCheck.GetTCP() != nil {
-		check.TCP = fmt.Sprintf("%s:%d", serviceHost, port)
-
+		check.TCP = executor.HealthCheckAddress(uint32(port))
 		return &check
 	}
 
@@ -201,7 +200,7 @@ func generateURL(info *mesos.HealthCheck_HTTPCheckInfo, port int) string {
 	const defaultHTTPScheme = "http"
 
 	var checkURL url.URL
-	checkURL.Host = fmt.Sprintf("%s:%d", serviceHost, port)
+	checkURL.Host = executor.HealthCheckAddress(uint32(port))
 	checkURL.Path = info.GetPath()
 	if info.GetScheme() != "" {
 		checkURL.Scheme = info.GetScheme()


### PR DESCRIPTION
Health checking service on loopback interface may be buggy, as it is not guaranteed that service will listen on it. We should use public host IP (if it is specified) to ensure service is available to the external hosts. It resolves #13 