### PR TITLE
Do not rely on mesos types

### DIFF
--- a/hook/consul/hook_test.go
+++ b/hook/consul/hook_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/allegro/mesos-executor/hook"
+	"github.com/allegro/mesos-executor/mesosutils"
 )
 
 func TestIfUsesLabelledPortsForServiceIDGen(t *testing.T) {
@@ -353,7 +354,7 @@ func createServiceId(taskId string, taskName string, port int) string {
 	return taskId + "_" + taskName + "_" + strconv.Itoa(port)
 }
 
-func prepareTaskInfo(taskID string, taskName string, consulName string, tags []string, ports []mesos.Port) mesos.TaskInfo {
+func prepareTaskInfo(taskID string, taskName string, consulName string, tags []string, ports []mesos.Port) mesosutils.TaskInfo {
 	seconds := 5.0
 	path := "/"
 	tagName := "tag"
@@ -373,7 +374,7 @@ func prepareTaskInfo(taskID string, taskName string, consulName string, tags []s
 
 	healthPort := ports[0].GetNumber()
 
-	return mesos.TaskInfo{
+	return mesosutils.TaskInfo{mesos.TaskInfo{
 		Discovery: &mesos.DiscoveryInfo{
 			Ports: &mesos.Ports{
 				Ports: ports,
@@ -394,7 +395,7 @@ func prepareTaskInfo(taskID string, taskName string, consulName string, tags []s
 				Path: &path,
 			},
 		},
-	}
+	}}
 }
 
 func createTestConsulServer(t *testing.T) (config *api.Config, server *testutil.TestServer) {

--- a/hook/hook.go
+++ b/hook/hook.go
@@ -2,7 +2,7 @@
 
 package hook
 
-import mesos "github.com/mesos/mesos-go/api/v1/lib"
+import "github.com/allegro/mesos-executor/mesosutils"
 
 // EventType represents task lifecycle event type.
 type EventType int
@@ -22,7 +22,7 @@ const (
 // Event is a container type for various event specific data.
 type Event struct {
 	Type     EventType
-	TaskInfo mesos.TaskInfo
+	TaskInfo mesosutils.TaskInfo
 }
 
 // Hook is an interface for various executor extensions, that can add some actions

--- a/hook/vaas/hook_test.go
+++ b/hook/vaas/hook_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/allegro/mesos-executor/runenv"
+	"github.com/allegro/mesos-executor/mesosutils"
 )
 
 type MockClient struct {
@@ -61,14 +62,14 @@ func (m *MockClient) TaskStatus(task *Task) error {
 	return args.Error(0)
 }
 
-func prepareTaskInfo() mesos.TaskInfo {
+func prepareTaskInfo() mesosutils.TaskInfo {
 	ports := mesos.Ports{Ports: []mesos.Port{{Number: uint32(8080)}}}
 	discovery := mesos.DiscoveryInfo{Ports: &ports}
 
-	return mesos.TaskInfo{Discovery: &discovery}
+	return mesosutils.TaskInfo{mesos.TaskInfo{Discovery: &discovery}}
 }
 
-func prepareTaskInfoWithDirector(directorName string, extraLabels ...mesos.Label) (taskInfo mesos.TaskInfo) {
+func prepareTaskInfoWithDirector(directorName string, extraLabels ...mesos.Label) (taskInfo mesosutils.TaskInfo) {
 	taskInfo = prepareTaskInfo()
 	tag := "tag"
 	directorLabel := mesos.Label{Key: "director", Value: &directorName}
@@ -76,9 +77,9 @@ func prepareTaskInfoWithDirector(directorName string, extraLabels ...mesos.Label
 	labelList := []mesos.Label{directorLabel, weightLabel}
 	labelList = append(labelList, extraLabels...)
 	labels := mesos.Labels{Labels: labelList}
-	taskInfo.Labels = &labels
+	taskInfo.TaskInfo.Labels = &labels
 
-	taskInfo.Command = &mesos.CommandInfo{}
+	taskInfo.TaskInfo.Command = &mesos.CommandInfo{}
 
 	return taskInfo
 }
@@ -140,7 +141,7 @@ func TestIfWeightIsOverriddenByEnvironmentVariable(t *testing.T) {
 	serviceHook := Hook{client: mockClient}
 
 	taskInfo := prepareTaskInfoWithDirector("abc456")
-	taskInfo.Command.Environment = &mesos.Environment{
+	taskInfo.TaskInfo.Command.Environment = &mesos.Environment{
 		Variables: []mesos.Environment_Variable{{"VAAS_INITIAL_WEIGHT", "15"}},
 	}
 

--- a/mesosutils/taskinfo.go
+++ b/mesosutils/taskinfo.go
@@ -22,8 +22,10 @@ type TaskInfo struct {
 type HealthCheckType int
 
 const (
+	// NONE represents empty healthcheck
+	NONE HealthCheckType = iota
 	// HTTP indicates HTTP field in HealthCheck is configured
-	HTTP HealthCheckType = iota
+	HTTP
 	// TCP indicates healthcheck is TCP
 	TCP
 	// COMMAND indicates healthcheck is a command
@@ -59,6 +61,14 @@ func (h TaskInfo) GetTaskID() TaskID {
 // GetHealthCheck returns
 func (h TaskInfo) GetHealthCheck() (check HealthCheck) {
 	mesosCheck := h.TaskInfo.GetHealthCheck()
+
+	if mesosCheck == nil ||
+		mesosCheck.IntervalSeconds == nil ||
+		mesosCheck.TimeoutSeconds == nil {
+		check.Type = NONE
+		return check
+	}
+
 	check.Interval = Duration(*mesosCheck.IntervalSeconds)
 	check.Timeout = Duration(*mesosCheck.TimeoutSeconds)
 

--- a/mesosutils/taskinfo_test.go
+++ b/mesosutils/taskinfo_test.go
@@ -5,7 +5,78 @@ import (
 
 	mesos "github.com/mesos/mesos-go/api/v1/lib"
 	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 )
+
+func TestIfGetTaskIDReturnsId(t *testing.T) {
+	taskInfo := TaskInfo{
+		TaskInfo: mesos.TaskInfo{},
+	}
+	assert.Equal (t, TaskID(""), taskInfo.GetTaskID())
+
+	taskInfo = TaskInfo{
+		TaskInfo: mesos.TaskInfo{TaskID: mesos.TaskID{Value: "task ID"}},
+	}
+	assert.Equal (t, TaskID("task ID"), taskInfo.GetTaskID())
+}
+
+func TestIfGetHealthChecksReturnsNoneWhenHealthCheckIsNotSet(t *testing.T) {
+	taskInfo := TaskInfo{
+		TaskInfo: mesos.TaskInfo{},
+	}
+	assert.Equal(t, NONE, taskInfo.GetHealthCheck().Type)
+}
+
+func TestIfGetHealthChecksReturnsNoneIfSomeDetailsAreMissing(t *testing.T) {
+	scheme := "ignored"
+	path := "/ping"
+	httpCheckDetails := mesos.HealthCheck_HTTPCheckInfo{
+		Scheme: &scheme,
+		Port: 8080,
+		Path: &path,
+	}
+	taskInfo := TaskInfo{
+		TaskInfo: mesos.TaskInfo{
+			HealthCheck: &mesos.HealthCheck{
+				Type: mesos.HealthCheck_HTTP.Enum(),
+				HTTP: &httpCheckDetails,
+			},
+		},
+	}
+	assert.Equal(t, NONE, taskInfo.GetHealthCheck().Type)
+}
+
+func TestIfGetHealthChecksReturnsHTTPWithAllDetails(t *testing.T) {
+	scheme := "ignored"
+	path := "/ping"
+	httpCheckDetails := mesos.HealthCheck_HTTPCheckInfo{
+		Scheme: &scheme,
+		Port: 8080,
+		Path: &path,
+	}
+	delaySeconds := 1.0
+	intervalSeconds := 2.0
+	timeoutSeconds := 3.0
+	gracePeriodSeconds := 4.0
+	consecutiveFailures := uint32(5)
+	taskInfo := TaskInfo{
+		TaskInfo: mesos.TaskInfo{
+			HealthCheck: &mesos.HealthCheck{
+				DelaySeconds: &delaySeconds,
+				IntervalSeconds: &intervalSeconds,
+				TimeoutSeconds: &timeoutSeconds,
+				GracePeriodSeconds: &gracePeriodSeconds,
+				ConsecutiveFailures: &consecutiveFailures,
+				Type: mesos.HealthCheck_HTTP.Enum(),
+				HTTP: &httpCheckDetails,
+			},
+		},
+	}
+	assert.Equal(t, HTTP, taskInfo.GetHealthCheck().Type)
+	assert.Equal(t, "/ping", taskInfo.GetHealthCheck().HTTP.Path)
+	assert.Equal(t, Duration(3), taskInfo.GetHealthCheck().Timeout)
+	assert.Equal(t, Duration(2), taskInfo.GetHealthCheck().Interval)
+}
 
 func TestIfExtractsServiceIDFromLabel(t *testing.T) {
 	serviceIDLabelValue := "XXX"


### PR DESCRIPTION
Hooks should not rely on external structures.
We should use our custom object facade for Mesos types
instead of relying on objects from dependencies because it
will make impossible to develop hooks outside of the main repository.