### PR TITLE
Generate unique prefix for Graphite metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ $(COVERAGEDIR)/coverage.out: test-deps $(COVERAGEDIR) $(GO_SRC) $(TEST_TARGETS)
 	gover $(COVERAGEDIR) $(COVERAGEDIR)/coverage.out
 
 $(TEST_TARGETS):
-	go test -coverprofile=$(COVERAGEDIR)/$(shell basename $@).coverprofile $(TESTARGS) $@
+	go test -v -coverprofile=$(COVERAGEDIR)/$(shell basename $@).coverprofile $(TESTARGS) $@
 
 coveralls: test $(COVERAGEDIR)/coverage.out
 	goveralls -coverprofile=$(COVERAGEDIR)/coverage.out -service=travis-ci

--- a/metrics/graphite.go
+++ b/metrics/graphite.go
@@ -3,15 +3,21 @@ package metrics
 import (
 	"fmt"
 	"net"
+	"strings"
 	"time"
 
 	log "github.com/Sirupsen/logrus"
-	graphite "github.com/cyberdelia/go-metrics-graphite"
+	"github.com/cyberdelia/go-metrics-graphite"
 	"github.com/kelseyhightower/envconfig"
-	metrics "github.com/rcrowley/go-metrics"
+	"github.com/pborman/uuid"
+	"github.com/rcrowley/go-metrics"
+
+	"github.com/allegro/mesos-executor/runenv"
 )
 
 const graphiteConfigEnvPrefix = "allegro_executor_graphite"
+
+var metricsUUID = uuid.New()
 
 func init() {
 	var cfg GraphiteConfig
@@ -22,7 +28,7 @@ func init() {
 		if err := SetupGraphite(cfg); err != nil {
 			log.WithError(err).Fatal("Invalid graphite configuration")
 		} else {
-			log.Info("Metrics will be sent to Graphite")
+			log.Infof("Metrics will be sent to Graphite with UUID: %s", metricsUUID)
 		}
 	} else {
 		log.Info("No metric storage specified - using stderr to periodically print metrics")
@@ -42,8 +48,20 @@ type GraphiteConfig struct {
 func SetupGraphite(cfg GraphiteConfig) error {
 	addr, err := net.ResolveTCPAddr("tcp", fmt.Sprintf("%s:%d", cfg.Host, cfg.Port))
 	if err != nil {
-		return fmt.Errorf("Invalid Graphite address: %s", err)
+		return fmt.Errorf("invalid Graphite address: %s", err)
 	}
-	go graphite.Graphite(metrics.DefaultRegistry, time.Minute, cfg.Prefix, addr)
+	go graphite.Graphite(metrics.DefaultRegistry, time.Minute, buildUniquePrefix(cfg.Prefix), addr)
 	return nil
+}
+
+func buildUniquePrefix(basePrefix string) string {
+	hostname, err := runenv.Hostname()
+	if err != nil {
+		log.Fatalf("Unable to get hostname for metrics key: %s", err)
+	}
+	return fmt.Sprintf("%s.%s.%s", basePrefix, normalizeValue(hostname), metricsUUID)
+}
+
+func normalizeValue(value string) string {
+	return strings.Replace(value, ".", "_", -1)
 }

--- a/metrics/graphite_test.go
+++ b/metrics/graphite_test.go
@@ -1,6 +1,8 @@
 package metrics
 
 import (
+	"fmt"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -23,4 +25,25 @@ func TestIfNotFailsToSetupGraphiteWithValidConfig(t *testing.T) {
 	err := SetupGraphite(cfg)
 
 	assert.NoError(t, err)
+}
+
+func TestIfBuildsCorrectMetricsPrefix(t *testing.T) {
+	metricsUUID = "uuid"
+	testCases := []struct {
+		hostname       string
+		expectedPrefix string
+	}{
+		{"localhost", "basePrefix.localhost.uuid"},
+		{"my.host.with.dots", "basePrefix.my_host_with_dots.uuid"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("hostname=%s", tc.hostname), func(t *testing.T) {
+			os.Setenv("MESOS_HOSTNAME", tc.hostname)
+			defer os.Unsetenv("MESOS_HOSTNAME")
+
+			actualPrefix := buildUniquePrefix("basePrefix")
+			assert.Equal(t, tc.expectedPrefix, actualPrefix)
+		})
+	}
 }


### PR DESCRIPTION
Current implementation of Graphite metrics writes all metrics under the same key. As a result, the metrics of each instance are merged under one key. This commit adds a hostname and UUID to each metric prefix, so each instance will have a unique key.