### PR TITLE
Remove -static ld flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 APPLICATION_NAME    := github.com/allegro/mesos-executor
 APPLICATION_VERSION := $(shell cat VERSION)
 
-LDFLAGS := -X main.Version=$(APPLICATION_VERSION) -extldflags "-static"
+LDFLAGS := -X main.Version=$(APPLICATION_VERSION)
 USER_ID := `id -u $$USER`
 
 BUILD_FOLDER := target


### PR DESCRIPTION
Remove -static ld flag as it is no longer needed and may cause linking errors on OS X.