### PR TITLE
Enable setting environment variables via Hooks

### DIFF
--- a/command.go
+++ b/command.go
@@ -13,7 +13,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/allegro/mesos-executor/servicelog/appender"
 	"github.com/allegro/mesos-executor/servicelog/scraper"
-	mesos "github.com/mesos/mesos-go/api/v1/lib"
+	"github.com/mesos/mesos-go/api/v1/lib"
 
 	osutil "github.com/allegro/mesos-executor/os"
 )
@@ -51,7 +51,7 @@ type cancellableCommand struct {
 
 func (c *cancellableCommand) Start() error {
 	if c.cmd == nil {
-		return errors.New("Missing command to run")
+		return errors.New("missing command to run")
 	}
 
 	if err := c.cmd.Start(); err != nil {

--- a/hook/consul/hook.go
+++ b/hook/consul/hook.go
@@ -46,15 +46,15 @@ type Config struct {
 
 // HandleEvent calls appropriate hook functions that correspond to supported
 // event types. Unsupported events are ignored.
-func (h *Hook) HandleEvent(event hook.Event) error {
+func (h *Hook) HandleEvent(event hook.Event) (hook.Env, error) {
 	switch event.Type {
 	case hook.AfterTaskHealthyEvent:
-		return h.RegisterIntoConsul(event.TaskInfo)
+		return nil, h.RegisterIntoConsul(event.TaskInfo)
 	case hook.BeforeTerminateEvent:
-		return h.DeregisterFromConsul(event.TaskInfo)
+		return nil, h.DeregisterFromConsul(event.TaskInfo)
 	default:
 		log.Debugf("Received unsupported event type %s - ignoring", event.Type)
-		return nil // ignore unsupported events
+		return nil, nil // ignore unsupported events
 	}
 }
 

--- a/hook/consul/hook_test.go
+++ b/hook/consul/hook_test.go
@@ -290,7 +290,7 @@ func TestIfNoErrorOnUnsupportedEvent(t *testing.T) {
 
 	require.NoError(t, err)
 
-	err = h.HandleEvent(hook.Event{
+	_, err = h.HandleEvent(hook.Event{
 		Type: hook.BeforeTaskStartEvent,
 	})
 

--- a/hook/hook.go
+++ b/hook/hook.go
@@ -25,6 +25,9 @@ type Event struct {
 	TaskInfo mesosutils.TaskInfo
 }
 
+// Env is a container for os.Environ style list of combined environment variable strings.
+type Env []string
+
 // Hook is an interface for various executor extensions, that can add some actions
 // during task lifecycle events.
 type Hook interface {
@@ -32,5 +35,5 @@ type Hook interface {
 	// Received events may be handled in any way, but hook should ignore unknown or
 	// unsupported ones. Call to this function will block executor process until
 	// it returns. Order of received event types is undefined.
-	HandleEvent(Event) error
+	HandleEvent(Event) (Env, error)
 }

--- a/hook/manager.go
+++ b/hook/manager.go
@@ -1,6 +1,8 @@
 package hook
 
-import log "github.com/Sirupsen/logrus"
+import (
+	log "github.com/Sirupsen/logrus"
+)
 
 // Manager is a helper type that simplifies calling group of hooks and handling
 // returned errors.
@@ -12,16 +14,21 @@ type Manager struct {
 // call error when ignoreErrors argument is false. When ignoreErrors is set to
 // true it will only log errors returned from each hook and will never return an
 // error itself.
-func (m *Manager) HandleEvent(event Event, ignoreErrors bool) error {
+func (m *Manager) HandleEvent(event Event, ignoreErrors bool) (Env, error) {
+	var combinedEnv = Env{}
 	for _, hook := range m.Hooks {
 		log.Infof("Calling %T hook to handle %s", hook, event.Type)
-		if err := hook.HandleEvent(event); err != nil {
+
+		moreEnvValues, err := hook.HandleEvent(event)
+		if err != nil {
 			if !ignoreErrors {
-				return err
+				return nil, err
 			}
 			log.WithError(err).Errorf("%T hook failed to handle %s", hook, event.Type)
+		} else {
+			combinedEnv = append(combinedEnv, moreEnvValues...)
 		}
 	}
 
-	return nil
+	return combinedEnv, nil
 }

--- a/hook/manager_test.go
+++ b/hook/manager_test.go
@@ -11,13 +11,13 @@ import (
 func TestIfFailsOnFirstError(t *testing.T) {
 	testErr := errors.New("test")
 	hook1 := new(mockHook)
-	hook1.On("HandleEvent", mock.AnythingOfType("hook.Event")).Return(testErr).Once()
+	hook1.On("HandleEvent", mock.AnythingOfType("hook.Event")).Return(Env{}, testErr).Once()
 
 	hook2 := new(mockHook)
-	hook2.On("HandleEvent", mock.AnythingOfType("hook.Event")).Return(testErr).Once()
+	hook2.On("HandleEvent", mock.AnythingOfType("hook.Event")).Return(Env{}, testErr).Once()
 
 	manager := Manager{Hooks: []Hook{hook1, hook2}}
-	err := manager.HandleEvent(Event{}, false)
+	_, err := manager.HandleEvent(Event{}, false)
 
 	assert.Error(t, err)
 	hook1.AssertExpectations(t)
@@ -27,13 +27,13 @@ func TestIfFailsOnFirstError(t *testing.T) {
 func TestIfIgnoresErrors(t *testing.T) {
 	testErr := errors.New("test")
 	hook1 := new(mockHook)
-	hook1.On("HandleEvent", mock.AnythingOfType("hook.Event")).Return(testErr).Once()
+	hook1.On("HandleEvent", mock.AnythingOfType("hook.Event")).Return(Env{}, testErr).Once()
 
 	hook2 := new(mockHook)
-	hook2.On("HandleEvent", mock.AnythingOfType("hook.Event")).Return(nil).Once()
+	hook2.On("HandleEvent", mock.AnythingOfType("hook.Event")).Return(Env{}, nil).Once()
 
 	manager := Manager{Hooks: []Hook{hook1, hook2}}
-	err := manager.HandleEvent(Event{}, true)
+	_, err := manager.HandleEvent(Event{}, true)
 
 	assert.NoError(t, err)
 	hook1.AssertExpectations(t)
@@ -44,7 +44,7 @@ type mockHook struct {
 	mock.Mock
 }
 
-func (m *mockHook) HandleEvent(event Event) error {
+func (m *mockHook) HandleEvent(event Event) (Env, error) {
 	args := m.Called(event)
-	return args.Error(0)
+	return args.Get(0).(Env), args.Error(1)
 }

--- a/hook/vaas/hook.go
+++ b/hook/vaas/hook.go
@@ -198,15 +198,15 @@ func (sh *Hook) watchTaskStatus(task *Task) (err error) {
 
 // HandleEvent calls appropriate hook functions that correspond to supported
 // event types. Unsupported events are ignored.
-func (sh *Hook) HandleEvent(event hook.Event) error {
+func (sh *Hook) HandleEvent(event hook.Event) (hook.Env, error) {
 	switch event.Type {
 	case hook.AfterTaskHealthyEvent:
-		return sh.RegisterBackend(event.TaskInfo)
+		return nil, sh.RegisterBackend(event.TaskInfo)
 	case hook.BeforeTerminateEvent:
-		return sh.DeregisterBackend(event.TaskInfo)
+		return nil, sh.DeregisterBackend(event.TaskInfo)
 	default:
 		log.Debugf("Received unsupported event type %s - ignoring", event.Type)
-		return nil // ignore unsupported events
+		return nil, nil // ignore unsupported events
 	}
 }
 

--- a/hook/vaas/hook_test.go
+++ b/hook/vaas/hook_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/allegro/mesos-executor/mesosutils"
 	"github.com/allegro/mesos-executor/runenv"
+	"github.com/allegro/mesos-executor/hook"
 )
 
 type MockClient struct {
@@ -321,4 +322,16 @@ func TestIfAsyncBackendRegistrationTimesOutWhenVaasErrorOccurs(t *testing.T) {
 	expectedId := 123
 	assert.Equal(t, &expectedId, serviceHook.backendID)
 	mockClient.AssertExpectations(t)
+}
+
+func TestIfNoErrorOnUnsupportedEvent(t *testing.T) {
+	h, err := NewHook(Config{})
+
+	require.NoError(t, err)
+
+	_, err = h.HandleEvent(hook.Event{
+		Type: hook.BeforeTaskStartEvent,
+	})
+
+	require.NoError(t, err)
 }

--- a/mesosutils/taskinfo_test.go
+++ b/mesosutils/taskinfo_test.go
@@ -263,3 +263,23 @@ func TestGetWeightReturnsWeightFromTagLabel(t *testing.T) {
 	require.Equal(t, 50, weight)
 	require.NoError(t, err)
 }
+
+func TestFindEnvValueReturnsCorrectValue(t *testing.T) {
+	expectedValue := "test env value"
+	key := "TEST_ENV_KEY"
+	vars := []mesos.Environment_Variable{
+		{Name: key, Value: expectedValue},
+	}
+	mesosTaskInfo := mesos.TaskInfo{
+		Command: &mesos.CommandInfo{
+			Environment: &mesos.Environment{Variables: vars},
+		},
+	}
+	taskInfo := TaskInfo{
+		TaskInfo: mesosTaskInfo,
+	}
+
+	returnedValue := taskInfo.FindEnvValue(key)
+
+	require.Equal(t, expectedValue, returnedValue)
+}


### PR DESCRIPTION
This allows for setting application environment via Hooks (for remote configuration retrieval purposes).