### PR TITLE
Add configuration for service log scraping

### DIFF
--- a/command_test.go
+++ b/command_test.go
@@ -12,7 +12,7 @@ import (
 func TestIfNewCancellableCommandReturnsCommand(t *testing.T) {
 	os.Environ()
 	commandInfo := newCommandInfo("./sleep 100", "ignored", false, []string{"ignored"}, map[string]string{"one": "1", "two": "2"})
-	command, err := NewCommand(commandInfo, nil, nil)
+	command, err := NewCommand(commandInfo, nil)
 	cmd := command.(*cancellableCommand).cmd
 
 	assert.NoError(t, err)

--- a/servicelog/appender/logstash.go
+++ b/servicelog/appender/logstash.go
@@ -7,14 +7,21 @@ import (
 	"time"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/kelseyhightower/envconfig"
 
 	"github.com/allegro/mesos-executor/servicelog"
 )
 
 const (
 	logstashVersion           = "1"
+	logstashConfigPrefix      = "allegro_executor_servicelog_logstash"
 	logstashDefaultTimeFormat = time.RFC3339Nano
 )
+
+type logstashConfig struct {
+	Protocol string `required:"true"`
+	Address  string `required:"true"`
+}
 
 type logstash struct {
 	conn net.Conn
@@ -45,10 +52,37 @@ func (l logstash) sendEntry(entry servicelog.Entry) error {
 }
 
 // NewLogstash creates new appender that will send log entries to Logstash.
-func NewLogstash(protocol, address string) (Appender, error) {
-	conn, err := net.Dial(protocol, address)
-	if err != nil {
-		return nil, fmt.Errorf("unable to connect to Logstash server: %s", err)
+func NewLogstash(options ...func(*logstash) error) (Appender, error) {
+	l := &logstash{}
+	for _, option := range options {
+		if err := option(l); err != nil {
+			return nil, fmt.Errorf("invalid config option: %s", err)
+		}
 	}
-	return &logstash{conn: conn}, nil
+	return l, nil
+}
+
+// LogstashAddress sets the connection details for the Logstash appender.
+func LogstashAddress(protocol, address string) func(*logstash) error {
+	return func(l *logstash) error {
+		conn, err := net.Dial(protocol, address)
+		if err != nil {
+			return fmt.Errorf("unable to connect to Logstash server: %s", err)
+		}
+		l.conn = conn
+		return nil
+	}
+}
+
+// LogstashAddressFromEnv sets the connection details from the environment
+// variables for the Logstash appender.
+func LogstashAddressFromEnv() func(*logstash) error {
+	config := &logstashConfig{}
+	err := envconfig.Process(logstashConfigPrefix, config)
+	if err != nil {
+		return func(l *logstash) error {
+			return fmt.Errorf("unable to get address from env: %s", err)
+		}
+	}
+	return LogstashAddress(config.Protocol, config.Address)
 }

--- a/servicelog/scraper/scraper.go
+++ b/servicelog/scraper/scraper.go
@@ -11,9 +11,10 @@ type Scraper interface {
 	StartScraping(io.Reader) <-chan servicelog.Entry
 }
 
-// Pipe returns writer that can be used as a data provider for given scraper.
-func Pipe(scraper Scraper) io.Writer {
+// Pipe returns a channel with log entries and writer that can be used as a data
+// provider for given scraper.
+func Pipe(scraper Scraper) (<-chan servicelog.Entry, io.Writer) {
 	reader, writer := io.Pipe()
-	scraper.StartScraping(reader)
-	return writer
+	entries := scraper.StartScraping(reader)
+	return entries, writer
 }


### PR DESCRIPTION
Log scraping can be now enabled by adding log-scraping label to the Mesos TaskInfo. Only scraping logs in logfmt format and sending them to Logstash is supported by now.