### PR TITLE
Add ability to filter log keys during scraping

### DIFF
--- a/servicelog/scraper/filter.go
+++ b/servicelog/scraper/filter.go
@@ -1,0 +1,34 @@
+package scraper
+
+import "bytes"
+
+// Filter is an interface that performs filtering tasks during log scraping. It
+// allows to ignore log values based on implementation logic.
+type Filter interface {
+	Match([]byte) bool
+}
+
+// The FilterFunc type is an adapter to allow the use of ordinary functions as
+// scraping filters. If f is a function with the appropriate signature,
+// FilterFunc(f) is a Filter that calls f.
+type FilterFunc func([]byte) bool
+
+// Match calls f(value).
+func (f FilterFunc) Match(value []byte) bool {
+	return f(value)
+}
+
+// ValueFilter allows to ignore specific values during log scraping.
+type ValueFilter struct {
+	Values [][]byte
+}
+
+// Match returns true if passed value is on the filtered list - false otherwise.
+func (f ValueFilter) Match(v []byte) bool {
+	for _, value := range f.Values {
+		if bytes.Equal(v, value) {
+			return true
+		}
+	}
+	return false
+}

--- a/servicelog/scraper/filter_test.go
+++ b/servicelog/scraper/filter_test.go
@@ -1,0 +1,31 @@
+package scraper
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIfFiltersConfiguredValues(t *testing.T) {
+	testCases := []struct {
+		filteredValues [][]byte
+		value          []byte
+		match          bool
+	}{
+		{[][]byte{[]byte("a")}, []byte("a"), true},
+		{[][]byte{[]byte("a")}, []byte("b"), false},
+		{[][]byte{[]byte("a"), []byte("b"), []byte("c")}, []byte("d"), false},
+		{[][]byte{[]byte("a"), []byte("b"), []byte("c")}, []byte("a"), true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("filter=%s;value=%s", tc.filteredValues, tc.value), func(t *testing.T) {
+			filter := ValueFilter{
+				Values: tc.filteredValues,
+			}
+			match := filter.Match(tc.value)
+			assert.Equal(t, tc.match, match)
+		})
+	}
+}

--- a/servicelog/scraper/logfmt.go
+++ b/servicelog/scraper/logfmt.go
@@ -12,6 +12,7 @@ import (
 //
 // See: https://brandur.org/logfmt
 type LogFmt struct {
+	KeyFilter Filter
 }
 
 // StartScraping starts scraping logs in logfmt format from given reader and sends
@@ -26,9 +27,12 @@ func (logFmt *LogFmt) StartScraping(reader io.Reader) <-chan servicelog.Entry {
 			logEntry := servicelog.Entry{}
 
 			for decoder.ScanKeyval() {
-				key := string(decoder.Key())
+				key := decoder.Key()
+				if logFmt.KeyFilter != nil && logFmt.KeyFilter.Match(key) {
+					continue
+				}
 				value := string(decoder.Value())
-				logEntry[key] = value
+				logEntry[string(key)] = value
 			}
 
 			logEntries <- logEntry

--- a/servicelog/scraper/logfmt_test.go
+++ b/servicelog/scraper/logfmt_test.go
@@ -1,6 +1,7 @@
 package scraper
 
 import (
+	"bytes"
 	"io"
 	"testing"
 
@@ -18,4 +19,19 @@ func TestIfScrapsLogsProperlyInLogFmtFormat(t *testing.T) {
 
 	assert.Equal(t, "b", entry["a"])
 	assert.Equal(t, "d", entry["c"])
+}
+
+func TestIfFiltersKeysFromScrapedLogs(t *testing.T) {
+	reader, writer := io.Pipe()
+	scraper := LogFmt{
+		KeyFilter: FilterFunc(func(v []byte) bool { return bytes.Equal(v, []byte("a")) }),
+	}
+
+	entries := scraper.StartScraping(reader)
+	go writer.Write([]byte("a=b c=d\n"))
+
+	entry := <-entries
+
+	assert.Equal(t, "d", entry["c"])
+	assert.Len(t, entry, 1)
 }


### PR DESCRIPTION
Log keys specified in the `ALLEGRO_EXECUTOR_SERVICELOG_IGNORE_KEYS` environment variable will be ignored (not scraped). It resolves #31 