### PR TITLE
Add ability to extend log entries

### DIFF
--- a/command.go
+++ b/command.go
@@ -11,11 +11,12 @@ import (
 	"time"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/allegro/mesos-executor/servicelog/appender"
-	"github.com/allegro/mesos-executor/servicelog/scraper"
 	"github.com/mesos/mesos-go/api/v1/lib"
 
 	osutil "github.com/allegro/mesos-executor/os"
+	"github.com/allegro/mesos-executor/servicelog"
+	"github.com/allegro/mesos-executor/servicelog/appender"
+	"github.com/allegro/mesos-executor/servicelog/scraper"
 )
 
 // TaskExitState is a type describing reason of program execution interuption.
@@ -159,9 +160,10 @@ func ForwardCmdOutput() func(*exec.Cmd) error {
 
 // ScrapCmdOutput configures command so itd output will be scraped and forwarded
 // by provided log appender.
-func ScrapCmdOutput(s scraper.Scraper, a appender.Appender) func(*exec.Cmd) error {
+func ScrapCmdOutput(s scraper.Scraper, a appender.Appender, extenders ...servicelog.Extender) func(*exec.Cmd) error {
 	return func(cmd *exec.Cmd) error {
 		entries, writer := scraper.Pipe(s)
+		entries = servicelog.Extend(entries, extenders...)
 		cmd.Stderr = writer
 		cmd.Stdout = writer
 		go a.Append(entries)

--- a/servicelog/entry.go
+++ b/servicelog/entry.go
@@ -1,4 +1,81 @@
 package servicelog
 
+import (
+	"github.com/allegro/mesos-executor/runenv"
+)
+
 // Entry represents one scraped log line in flat key-value store.
 type Entry map[string]string
+
+// Extender is type used to extend log data with additional data.
+type Extender interface {
+	// Extend returns a new log entry, based on the passed one, with additional
+	// data. Original entry is not modified but duplicate keys are overwritten in
+	// returned entry.
+	Extend(Entry) Entry
+}
+
+// Extend returns a channel that will return log entries extended with passed
+// extenders list. Original log entries are not modified, but duplicate keys are
+// overwritten in returned ones.
+func Extend(in <-chan Entry, extenders ...Extender) <-chan Entry {
+	if len(extenders) == 0 {
+		return in
+	}
+	out := make(chan Entry)
+	go func() {
+		for entry := range in {
+			extendedEntry := entry
+			for _, extender := range extenders {
+				extendedEntry = extender.Extend(extendedEntry)
+			}
+			out <- extendedEntry
+		}
+	}()
+	return out
+}
+
+// SystemDataExtender adds system specific data to passed log entry. It only
+// adds data that is able to get.
+type SystemDataExtender struct {
+}
+
+// Extend returns a new log entry, based on the passed entry, with hostname, region
+// and availability zone added to it. Data is added only when it is possible to
+// retrieve it from the system.
+func (e SystemDataExtender) Extend(entry Entry) Entry {
+	extendedEntry := Entry{}
+	for key, value := range entry {
+		extendedEntry[key] = value
+	}
+	e.setIfNoError(extendedEntry, "srchost", runenv.Hostname)
+	e.setIfNoError(extendedEntry, "region", runenv.Region)
+	e.setIfNoError(extendedEntry, "zone", runenv.AvailabilityZone)
+	return extendedEntry
+}
+
+func (e SystemDataExtender) setIfNoError(entry Entry, key string, dataFunc func() (string, error)) {
+	data, err := dataFunc()
+	if err != nil {
+		return
+	}
+	entry[key] = data
+}
+
+// StaticDataExtender adds data specified in the Data field to passed log entry.
+type StaticDataExtender struct {
+	Data map[string]string
+}
+
+// Extend returns a new log entry, based on the passed entry, with Data map
+// added to it.
+func (e StaticDataExtender) Extend(entry Entry) Entry {
+	extendedEntry := Entry{}
+	for key, value := range entry {
+		extendedEntry[key] = value
+	}
+	for key, value := range e.Data {
+		extendedEntry[key] = value
+	}
+	return extendedEntry
+}

--- a/servicelog/entry_test.go
+++ b/servicelog/entry_test.go
@@ -1,0 +1,40 @@
+package servicelog
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIfAddsSystemDataToLogEntry(t *testing.T) {
+	os.Setenv("MESOS_HOSTNAME", "hostname")
+	defer os.Unsetenv("MESOS_HOSTNAME")
+
+	extender := SystemDataExtender{}
+	logEntry := Entry{"key": "value"}
+
+	extendedLogEntry := extender.Extend(logEntry)
+
+	assert.Len(t, logEntry, 1)
+	assert.Len(t, extendedLogEntry, 2)
+	assert.Equal(t, "value", extendedLogEntry["key"])
+	assert.Equal(t, "hostname", extendedLogEntry["srchost"])
+}
+
+func TestIfAddsStaticDataToLogEntry(t *testing.T) {
+	extender := StaticDataExtender{
+		Data: map[string]string{
+			"data1": "data1",
+			"data2": "data2",
+		},
+	}
+	logEntry := Entry{"key": "value"}
+
+	extendedLogEntry := extender.Extend(logEntry)
+
+	assert.Len(t, logEntry, 1)
+	assert.Len(t, extendedLogEntry, 3)
+	assert.Equal(t, "data1", extendedLogEntry["data1"])
+	assert.Equal(t, "data2", extendedLogEntry["data2"])
+}


### PR DESCRIPTION
This commit add a mechanism that allows to add additional elements to `servicelog.Entry` during service log scraping process. Structures implementing `servicelog.Extender` interface can be used as a decorators for the log entries channel with the help of `servicelog.Extend` function. It resolves #33 