### PR TITLE
Fix servicelog.Entry map value type

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"time"
 
@@ -391,11 +392,15 @@ func (e *Executor) createOptionsForLogstashServiceLogScrapping(taskInfo mesos.Ta
 	if err != nil {
 		return nil, fmt.Errorf("cannot configure service log scraping: %s", err)
 	}
+	scid, err := strconv.Atoi(utilTaskInfo.GetLabelValue("scId"))
+	if err != nil {
+		return nil, fmt.Errorf("cannot parse scid: %s", err)
+	}
 	extenders := []servicelog.Extender{
 		servicelog.StaticDataExtender{
-			Data: map[string]string{
+			Data: map[string]interface{}{
 				"instance-id": taskInfo.Executor.ExecutorID.String(),
-				"scid":        utilTaskInfo.GetLabelValue("scId"),
+				"scid":        scid,
 			},
 		},
 		servicelog.SystemDataExtender{},

--- a/servicelog/appender/logstash.go
+++ b/servicelog/appender/logstash.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	logstashVersion      = "1"
+	logstashVersion      = 1
 	logstashConfigPrefix = "allegro_executor_servicelog_logstash"
 )
 
@@ -21,7 +21,7 @@ type logstashConfig struct {
 	Address  string `required:"true"`
 }
 
-type logstashEntry map[string]string
+type logstashEntry map[string]interface{}
 
 type logstash struct {
 	conn net.Conn

--- a/servicelog/appender/logstash_test.go
+++ b/servicelog/appender/logstash_test.go
@@ -23,7 +23,7 @@ func TestIfSendsLogsToLogstash(t *testing.T) {
 		bytes, _, err := reader.ReadLine()
 
 		require.NoError(t, err)
-		assert.Contains(t, string(bytes), "\"@version\":\"1\"")
+		assert.Contains(t, string(bytes), "\"@version\":1")
 		assert.Contains(t, string(bytes), "@timestamp")
 
 		done <- struct{}{}
@@ -50,7 +50,7 @@ func TestIfFormatsLogsCorrectly(t *testing.T) {
 	formattedEntry := logstash.formatEntry(servicelogEntry)
 
 	assert.Equal(t, "time", formattedEntry["@timestamp"])
-	assert.Equal(t, "1", formattedEntry["@version"])
+	assert.Equal(t, 1, formattedEntry["@version"])
 	assert.Equal(t, "log message", formattedEntry["message"])
 	assert.Equal(t, "WARNING", formattedEntry["level"])
 	assert.Equal(t, "my logger", formattedEntry["logger"])

--- a/servicelog/entry.go
+++ b/servicelog/entry.go
@@ -5,7 +5,7 @@ import (
 )
 
 // Entry represents one scraped log line in flat key-value store.
-type Entry map[string]string
+type Entry map[string]interface{}
 
 // Extender is type used to extend log data with additional data.
 type Extender interface {
@@ -64,7 +64,7 @@ func (e SystemDataExtender) setIfNoError(entry Entry, key string, dataFunc func(
 
 // StaticDataExtender adds data specified in the Data field to passed log entry.
 type StaticDataExtender struct {
-	Data map[string]string
+	Data map[string]interface{}
 }
 
 // Extend returns a new log entry, based on the passed entry, with Data map

--- a/servicelog/entry_test.go
+++ b/servicelog/entry_test.go
@@ -24,7 +24,7 @@ func TestIfAddsSystemDataToLogEntry(t *testing.T) {
 
 func TestIfAddsStaticDataToLogEntry(t *testing.T) {
 	extender := StaticDataExtender{
-		Data: map[string]string{
+		Data: map[string]interface{}{
 			"data1": "data1",
 			"data2": "data2",
 		},


### PR DESCRIPTION
`servicelog.Entry` map values cannot be simply strings because it causes loss of information about the value original type, which causes that after later serialization numeric values are represented as strings.