### PR TITLE
Add additional logging for service log scraping

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -131,6 +131,8 @@ func NewExecutor(cfg Config, hooks ...hook.Hook) *Executor {
 	log.Infof("RecoveryTimeout             = %s", cfg.MesosConfig.RecoveryTimeout)
 	log.Infof("SubscriptionBackoffMax      = %s", cfg.MesosConfig.SubscriptionBackoffMax)
 	log.Infof("APIPath                     = %s", cfg.APIPath)
+	log.Infof("Debug                       = %t", cfg.Debug)
+	log.Infof("ServicelogIgnoreKeys        = %s", cfg.ServicelogIgnoreKeys)
 
 	ctx, ctxCancel := context.WithCancel(context.Background())
 	return &Executor{
@@ -338,12 +340,14 @@ func (e *Executor) launchTask(taskInfo mesos.TaskInfo) (Command, error) {
 	var cmdOption func(*exec.Cmd) error
 	switch utilTaskInfo.GetLabelValue("log-scraping") {
 	case "logstash":
+		log.Info("Service logs will be forwarded to Logstash")
 		options, err := e.createOptionsForLogstashServiceLogScrapping(taskInfo)
 		if err != nil {
 			return nil, err
 		}
 		cmdOption = options
 	default:
+		log.Info("Service logs will be forwarded to stdout/stderr")
 		cmdOption = ForwardCmdOutput()
 	}
 

--- a/servicelog/appender/logstash.go
+++ b/servicelog/appender/logstash.go
@@ -57,6 +57,7 @@ func (l logstash) sendEntry(entry servicelog.Entry) error {
 	if err != nil {
 		return fmt.Errorf("unable to marshal log entry: %s", err)
 	}
+	log.WithField("entry", string(bytes)).Debug("Sending log entry to Logstash")
 	if _, err = l.conn.Write(bytes); err != nil {
 		return fmt.Errorf("unable to write to Logstash server: %s", err)
 	}


### PR DESCRIPTION
This commit adds additional logging for service log scraping, so it will be easy to tell if is it turned on. Additionally, when the executor is in the debug mode, Logstash json data will be printed on stderr.