### PR TITLE
Change instance-id log entry format

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -403,7 +403,7 @@ func (e *Executor) createOptionsForLogstashServiceLogScrapping(taskInfo mesos.Ta
 	extenders := []servicelog.Extender{
 		servicelog.StaticDataExtender{
 			Data: map[string]interface{}{
-				"instance-id": taskInfo.Executor.ExecutorID.String(),
+				"instance-id": taskInfo.Executor.ExecutorID.GetValue(),
 				"scid":        scid,
 			},
 		},


### PR DESCRIPTION
Value generated by protobuf `String()` method is completely unreadable, so it is better to just use the ExecutorID string value directly.