### PR TITLE
Add ability to force debug mode from command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,14 @@ If you want to test executor locally, you will need additionally:
 * [Vagrant][8]
 * [Ansible 2.2+][9]
 
+## Debug mode
+
+Executor offers a debug mode that provide extended logging and capabilities during
+runtime. Enabling this can significantly increase the amount of resources the 
+executor needs to operate, so do not turn this on, when it is not needed. To enable
+debug mode add `-debug` flag to executor command or set `ALLEGRO_EXECUTOR_DEBUG` 
+environment variable to `true`.
+
 ## Development
 
 ### Using Vagrant environment

--- a/cmd/executor/main.go
+++ b/cmd/executor/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"time"
 
@@ -26,7 +27,11 @@ var Version string
 // Config contains application configuration
 var Config executor.Config
 
+var debug = *flag.Bool("debug", false, "Forces executor debug mode")
+
 func init() {
+	flag.Parse()
+
 	if err := envconfig.Process(environmentPrefix, &Config); err != nil {
 		log.WithError(err).Fatal("Failed to load executor configuration")
 	}
@@ -35,7 +40,8 @@ func init() {
 		log.WithError(err).Fatal("Failed to initialize Sentry")
 	}
 
-	if Config.Debug {
+	if Config.Debug || debug {
+		Config.Debug = true
 		log.SetLevel(log.DebugLevel)
 	} else {
 		log.SetLevel(log.InfoLevel)


### PR DESCRIPTION
Currently the debug mode of executor is turned on by environmental variable, which is not very flexible (it requires mesos-slave and container restart). Turning it on via command line flag would be much more flexible. It resolves #43 