### PR TITLE
Change Logstash appender to use io.Writer

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -400,7 +400,11 @@ func (e *Executor) createOptionsForLogstashServiceLogScrapping(taskInfo mesos.Ta
 	scr := &scraper.LogFmt{
 		KeyFilter: filter,
 	}
-	apr, err := appender.NewLogstash(appender.LogstashAddressFromEnv())
+	writer, err := appender.LogstashWriterFromEnv()
+	if err != nil {
+		return nil, fmt.Errorf("cannot configure service log scraping: %s", err)
+	}
+	apr, err := appender.NewLogstash(writer)
 	if err != nil {
 		return nil, fmt.Errorf("cannot configure service log scraping: %s", err)
 	}

--- a/servicelog/appender/example_test.go
+++ b/servicelog/appender/example_test.go
@@ -1,0 +1,24 @@
+package appender_test
+
+import (
+	"log"
+	"net"
+
+	"github.com/allegro/mesos-executor/servicelog/appender"
+)
+
+func ExampleNewLogstash() {
+	// create writer that will be used to send logs
+	writer, err := net.DialUDP("udp", nil, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// create appender with desired options
+	_, err = appender.NewLogstash(writer,
+		appender.LogstashRateLimit(100),
+		appender.LogstashSizeLimit(16000))
+	if err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
Change Logstash appender to use simpler `io.Writer` interface instead of an extensive `net.Conn` interface, whose functions were not needed at all. This allows the use of decorators from the `xio` package (added an example of their usage).