### PR TITLE
Add common tag to consul

### DIFF
--- a/hook/consul/hook.go
+++ b/hook/consul/hook.go
@@ -82,6 +82,17 @@ func (h *Hook) RegisterIntoConsul(taskInfo mesosutils.TaskInfo) error {
 	ports := taskInfo.GetPorts()
 	globalTags := taskInfo.GetLabelKeysByValue(consulTagValue)
 
+	// When executor fails (e.g., OOM, host restarted) task will NOT
+	// be deregistered. This should be done by remote service reconciling
+	// state between mesos and consul. We are using marathon-consul.
+	// It requires task to be tagged with common tag: "marathon" by default.
+	// > common tag name added to every service registered in Consul,
+	// > should be unique for every Marathon-cluster connected to Consul
+	// https://github.com/allegro/marathon-consul/blob/1.4.2/config/config.go#L74
+	// TODO(janisz): Think about reading it from configuration
+	// for now we are using the default value of marathon-consul
+	globalTags = append(globalTags, "marathon")
+
 	var instancesToRegister []instance
 	for _, port := range ports {
 		portServiceName, err := getServiceLabel(port)

--- a/hook/consul/hook_test.go
+++ b/hook/consul/hook_test.go
@@ -172,13 +172,13 @@ func TestIfUsesPortLabelsForRegistration(t *testing.T) {
 		consulServiceName: "consulName",
 		consulServiceID:   createServiceId(taskID, consulName, 666),
 		port:              666,
-		tags:              []string{"hystrix", "metrics", "extras"},
+		tags:              []string{"hystrix", "metrics", "extras", "marathon"},
 	}
 	expectedService2 := instance{
 		consulServiceName: "consulName-secured",
 		consulServiceID:   createServiceId(taskID, consulNameSecond, 997),
 		port:              997,
-		tags:              []string{"metrics", "extras"},
+		tags:              []string{"metrics", "extras", "marathon"},
 	}
 
 	// Create a test Consul server
@@ -197,9 +197,9 @@ func TestIfUsesPortLabelsForRegistration(t *testing.T) {
 	services, _, err := client.Catalog().Services(&opts)
 	require.NoError(t, err)
 	require.Contains(t, services, consulName)
-	requireEqualElements(t, []string{"hystrix", "metrics", "extras"}, services[consulName])
+	requireEqualElements(t, expectedService.tags, services[consulName])
 	require.Contains(t, services, consulNameSecond)
-	requireEqualElements(t, []string{"metrics", "extras"}, services[consulNameSecond])
+	requireEqualElements(t, expectedService2.tags, services[consulNameSecond])
 }
 
 // requireEqualElements asserts that two slices are equal ignoring order of elements


### PR DESCRIPTION
Marathon-Consul is used to reconcile state for any differences that
could happen when executor failed (e.g. OOM, agent restart).
Marathon-Consul synchronizes only services registered with a common tag.
It's configurable and by default equal to "marathon".