### PR TITLE
Add optional rate/size limiting config

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -400,11 +400,7 @@ func (e *Executor) createOptionsForLogstashServiceLogScrapping(taskInfo mesos.Ta
 	scr := &scraper.LogFmt{
 		KeyFilter: filter,
 	}
-	writer, err := appender.LogstashWriterFromEnv()
-	if err != nil {
-		return nil, fmt.Errorf("cannot configure service log scraping: %s", err)
-	}
-	apr, err := appender.NewLogstash(writer)
+	apr, err := appender.LogstashAppenderFromEnv()
 	if err != nil {
 		return nil, fmt.Errorf("cannot configure service log scraping: %s", err)
 	}


### PR DESCRIPTION
Add optional rate and size limiting config for service log scraping in executor environment.