### PR TITLE
Extend Sender interface by adding a resource releasing logic

### DIFF
--- a/xnet/writer.go
+++ b/xnet/writer.go
@@ -13,23 +13,33 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// InstanceProvider is the channel where updated list of desired service are published
+// InstanceProvider is the channel where updated list of desired service are
+// published.
 type InstanceProvider <-chan []Address
 
-// SenderFunc sends payload to given Address
-type SenderFunc func(addr Address, payload []byte) (int, error)
+// Sender is a interface for different sending protocols through the network.
+type Sender interface {
+	// Send writes given payload to passed address. It returns number of bytes
+	// sent and error - if there was any.
+	Send(Address, []byte) (int, error)
+
+	// Release frees all system resources allocated by the Sender. It can be
+	// called many times - usually when the pool of used addresses changes.
+	Release() error
+}
 
 // Address of a service in IP:PORT format
 type Address string
 
-// RoundRobinWriter returns writer with round robin functionality. Every write could be sent to different backend.
-func RoundRobinWriter(instanceProvider InstanceProvider, sender SenderFunc) io.Writer {
+// RoundRobinWriter returns writer with round robin functionality. Every write
+// could be sent to different backend.
+func RoundRobinWriter(instanceProvider InstanceProvider, sender Sender) io.Writer {
 	return &roundRobinWriter{provider: instanceProvider, sender: sender, instances: nil}
 }
 
 type roundRobinWriter struct {
 	provider  InstanceProvider
-	sender    SenderFunc
+	sender    Sender
 	instances chan Address
 }
 
@@ -52,6 +62,9 @@ func (r *roundRobinWriter) updateInstances(newInstances []Address) {
 	for _, instance := range newInstances {
 		r.instances <- instance
 	}
+	if err := r.sender.Release(); err != nil {
+		log.WithError(err).Warn("Unable to release xnet.Sender resources")
+	}
 }
 
 func (r *roundRobinWriter) write(payload []byte) (int, error) {
@@ -60,28 +73,46 @@ func (r *roundRobinWriter) write(payload []byte) (int, error) {
 	// Enqueue instance for round robin behaviour
 	r.instances <- instance
 
-	return r.sender(instance, payload)
+	return r.sender.Send(instance, payload)
 }
 
-// UDPSender returns a SenderFunc that can write payload to the network Address and reuses single connection
-func UDPSender() (SenderFunc, error) {
-	conn, err := net.ListenUDP("udp", nil)
-	if err != nil {
-		return nil, fmt.Errorf("could not create connection: %s", err)
+// UDPSender is a Sender implementation that can write payload to the network
+// Address and reuses single system socket. It uses UDP packets to send data.
+type UDPSender struct {
+	conn *net.UDPConn
+}
+
+// Send sends given payload to passed address. Data is sent using UDP packets.
+// It returns number of bytes sent and error - if there was any.
+func (s *UDPSender) Send(addr Address, payload []byte) (int, error) {
+	if s.conn == nil {
+		conn, err := net.ListenUDP("udp", nil)
+		if err != nil {
+			return 0, fmt.Errorf("could not create connection: %s", err)
+		}
+		s.conn = conn
 	}
 
-	return func(addr Address, payload []byte) (int, error) {
-		udpAddr, err := addressToUDP(addr)
-		if err != nil {
-			return 0, fmt.Errorf("invalid address %s: %s", addr, err)
-		}
+	udpAddr, err := addressToUDP(addr)
+	if err != nil {
+		return 0, fmt.Errorf("invalid address %s: %s", addr, err)
+	}
 
-		n, err := conn.WriteTo(payload, &udpAddr)
-		if err != nil {
-			return 0, fmt.Errorf("could not sent payload to %s: %s", addr, err)
-		}
-		return n, nil
-	}, nil
+	n, err := s.conn.WriteTo(payload, &udpAddr)
+	if err != nil {
+		return 0, fmt.Errorf("could not sent payload to %s: %s", addr, err)
+	}
+	return n, nil
+}
+
+// Release frees system socket used by sender.
+func (s *UDPSender) Release() error {
+	if s.conn == nil {
+		return nil
+	}
+	err := s.conn.Close()
+	s.conn = nil
+	return err
 }
 
 func addressToUDP(addr Address) (net.UDPAddr, error) {
@@ -98,7 +129,8 @@ func addressToUDP(addr Address) (net.UDPAddr, error) {
 	return net.UDPAddr{IP: net.ParseIP(host), Port: port}, nil
 }
 
-// DiscoveryServiceInstanceProvider returns InstanceProvider that is updated with list of instances in interval
+// DiscoveryServiceInstanceProvider returns InstanceProvider that is updated with
+// list of instances in interval
 func DiscoveryServiceInstanceProvider(serviceName string, interval time.Duration, client DiscoveryServiceClient) InstanceProvider {
 	instancesChan := make(chan []Address)
 
@@ -124,7 +156,8 @@ func DiscoveryServiceInstanceProvider(serviceName string, interval time.Duration
 	return instancesChan
 }
 
-// DiscoveryServiceClient represents generic discovery service client that can return list of services
+// DiscoveryServiceClient represents generic discovery service client that can
+// return list of services
 type DiscoveryServiceClient interface {
 	// GetAddrsByName returns list of services with given name
 	GetAddrsByName(serviceName string) ([]Address, error)


### PR DESCRIPTION
We need to extend Sender interface with Release method, which allows us to release resources used by it - for example connections to hosts that are no longer in the pool.