### PR TITLE
Refactor udp sender unit tests

### DIFF
--- a/xnet/udp.go
+++ b/xnet/udp.go
@@ -1,0 +1,45 @@
+package xnet
+
+import (
+	"fmt"
+	"net"
+)
+
+// UDPSender is a Sender implementation that can write payload to the network
+// address and reuses single system socket. It uses UDP packets to send data.
+type UDPSender struct {
+	conn *net.UDPConn
+}
+
+// Send sends given payload to passed address. Data is sent using UDP packets.
+// It returns number of bytes sent and error - if there was any.
+func (s *UDPSender) Send(addr Address, payload []byte) (int, error) {
+	if s.conn == nil {
+		conn, err := net.ListenUDP("udp", nil)
+		if err != nil {
+			return 0, fmt.Errorf("could not create connection: %s", err)
+		}
+		s.conn = conn
+	}
+
+	udpAddr, err := net.ResolveUDPAddr("udp", string(addr))
+	if err != nil {
+		return 0, fmt.Errorf("invalid address %s: %s", addr, err)
+	}
+
+	n, err := s.conn.WriteTo(payload, udpAddr)
+	if err != nil {
+		return 0, fmt.Errorf("could not sent payload to %s: %s", addr, err)
+	}
+	return n, nil
+}
+
+// Release frees system socket used by sender.
+func (s *UDPSender) Release() error {
+	if s.conn == nil {
+		return nil
+	}
+	err := s.conn.Close()
+	s.conn = nil
+	return err
+}

--- a/xnet/udp_test.go
+++ b/xnet/udp_test.go
@@ -1,0 +1,33 @@
+package xnet
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/allegro/mesos-executor/xnet/xnettest"
+)
+
+func TestUDPNetworkSendShouldReturnErrorWhenConnectionUnavailable(t *testing.T) {
+	sender := &UDPSender{}
+
+	bytesSent, err := sender.Send("198.51.100.5", []byte("test")) // see RFC 5737 for more info about this IP address
+
+	assert.Error(t, err)
+	assert.Zero(t, bytesSent)
+}
+
+func TestUDPNetworkSendShouldReturnNumberOfSentBytes(t *testing.T) {
+	conn, result, err := xnettest.LoopbackPacketServer("udp")
+	require.NoError(t, err)
+	defer conn.Close()
+
+	sender := &UDPSender{}
+
+	bytesSent, err := sender.Send(Address(conn.LocalAddr().String()), []byte("test"))
+
+	assert.NoError(t, err)
+	assert.Equal(t, 4, bytesSent)
+	assert.Equal(t, []byte("test"), <-result)
+}

--- a/xnet/xnettest/server.go
+++ b/xnet/xnettest/server.go
@@ -5,9 +5,9 @@ import (
 )
 
 // LoopbackServer creates a new network Listener that is binded to the loopback
-// interface and can be used to test tcp/udp connections. Listener must be
-// closed at the end of the tests to release system resources. It returns
-// configured listener and the channel to which it will send received data.
+// interface and can be used to test tcp connections. Listener must be closed
+// at the end of the tests to release system resources. It returns configured
+// listener and the channel to which it will send received data.
 func LoopbackServer(network string) (net.Listener, <-chan []byte, error) {
 	listener, err := net.Listen(network, "127.0.0.1:0")
 	if err != nil {
@@ -34,4 +34,26 @@ func LoopbackServer(network string) (net.Listener, <-chan []byte, error) {
 		}
 	}()
 	return listener, results, nil
+}
+
+// LoopbackPacketServer starts listening for packets on loopback interface. It
+// returns configured connection and the channel to which it will send received
+// data.
+func LoopbackPacketServer(network string) (net.PacketConn, <-chan []byte, error) {
+	conn, err := net.ListenPacket(network, "127.0.0.1:0")
+	if err != nil {
+		return nil, nil, err
+	}
+	results := make(chan []byte)
+	go func() {
+		for {
+			buf := make([]byte, 1024)
+			n, _, err := conn.ReadFrom(buf)
+			if err != nil {
+				return
+			}
+			results <- buf[0:n]
+		}
+	}()
+	return conn, results, nil
 }


### PR DESCRIPTION
Refactor udp sender unit tests by moving udp test server to dedicated test package. Also moved udp sender code and tests to dedicated files.