### PR TITLE
Use executorId instead of generating UUID for metrics

### DIFF
--- a/cmd/executor/main.go
+++ b/cmd/executor/main.go
@@ -15,7 +15,7 @@ import (
 	"github.com/allegro/mesos-executor/hook"
 	"github.com/allegro/mesos-executor/hook/consul"
 	"github.com/allegro/mesos-executor/hook/vaas"
-	_ "github.com/allegro/mesos-executor/metrics"
+	"github.com/allegro/mesos-executor/metrics"
 	"github.com/allegro/mesos-executor/runenv"
 )
 
@@ -114,6 +114,7 @@ func main() {
 		log.WithError(err).Fatal("Failed to load Mesos configuration")
 	}
 	Config.MesosConfig = cfg
+	metrics.Init(cfg.ExecutorID)
 	exec := executor.NewExecutor(Config, createHooks()...)
 	if err := exec.Start(); err != nil {
 		log.WithError(err).Fatal("Executor exited with error")

--- a/metrics/graphite.go
+++ b/metrics/graphite.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/cyberdelia/go-metrics-graphite"
 	"github.com/kelseyhightower/envconfig"
-	"github.com/pborman/uuid"
 	"github.com/rcrowley/go-metrics"
 	log "github.com/sirupsen/logrus"
 
@@ -17,10 +16,13 @@ import (
 
 const graphiteConfigEnvPrefix = "allegro_executor_graphite"
 
-var metricsUUID = uuid.New()
+var metricsID string
 
-func init() {
+
+// Init processes the environment in search of Graphite configuration and sets up a connection
+func Init(id string) {
 	var cfg GraphiteConfig
+	metricsID = id
 	if err := envconfig.Process(graphiteConfigEnvPrefix, &cfg); err != nil {
 		log.WithError(err).Fatal("Invalid graphite configuration")
 	}
@@ -28,7 +30,7 @@ func init() {
 		if err := SetupGraphite(cfg); err != nil {
 			log.WithError(err).Fatal("Invalid graphite configuration")
 		} else {
-			log.Infof("Metrics will be sent to Graphite with UUID: %s", metricsUUID)
+			log.Infof("Metrics will be sent to Graphite with UUID: %s", metricsID)
 		}
 	} else {
 		log.Info("No metric storage specified - using stderr to periodically print metrics")
@@ -59,7 +61,7 @@ func buildUniquePrefix(basePrefix string) string {
 	if err != nil {
 		log.Fatalf("Unable to get hostname for metrics key: %s", err)
 	}
-	return fmt.Sprintf("%s.%s.%s", basePrefix, normalizeValue(hostname), metricsUUID)
+	return fmt.Sprintf("%s.%s.%s", basePrefix, normalizeValue(hostname), metricsID)
 }
 
 func normalizeValue(value string) string {

--- a/metrics/graphite_test.go
+++ b/metrics/graphite_test.go
@@ -28,7 +28,6 @@ func TestIfNotFailsToSetupGraphiteWithValidConfig(t *testing.T) {
 }
 
 func TestIfBuildsCorrectMetricsPrefix(t *testing.T) {
-	metricsUUID = "uuid"
 	testCases := []struct {
 		hostname       string
 		expectedPrefix string
@@ -42,7 +41,7 @@ func TestIfBuildsCorrectMetricsPrefix(t *testing.T) {
 			os.Setenv("MESOS_HOSTNAME", tc.hostname)
 			defer os.Unsetenv("MESOS_HOSTNAME")
 
-			actualPrefix := buildUniquePrefix("basePrefix")
+			actualPrefix := buildUniquePrefix("basePrefix", "uuid")
 			assert.Equal(t, tc.expectedPrefix, actualPrefix)
 		})
 	}


### PR DESCRIPTION
To allow grouping metrics by application name instead of genarating a UUID for every executor instance use it's executorId. 