### PR TITLE
Fix possible segfault during task killing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,13 @@
 language: go
 go:
   - 1.9.x
-  - master
 
 jobs:
   include:
-    - script: make travis-ci
-    - stage: GitHub Release
+    - stage: test
+      script: make travis-ci
+    - stage: release
+      if: tag =~ ^v AND branch = master
       script: make release
       deploy:
         provider: releases


### PR DESCRIPTION
It is possible that we get the TASK_KILL event before TASK_LAUNCH event, so we may not have the TaskInfo object at all.