### PR TITLE
Add more logging for service log scraping

### DIFF
--- a/servicelog/appender/logstash.go
+++ b/servicelog/appender/logstash.go
@@ -155,6 +155,17 @@ func LogstashAppenderFromEnv() (Appender, error) {
 	if err != nil {
 		return nil, fmt.Errorf("unable to get config from env: %s", err)
 	}
+
+	log.Info("Initializing Logstash appender with following configuration:")
+	log.Infof("Protocol                 = %s", config.Protocol)
+	log.Infof("Address                  = %s", config.Address)
+	log.Infof("DiscoveryRefreshInterval = %s", config.DiscoveryRefreshInterval)
+	log.Infof("DiscoveryServiceName     = %s", config.DiscoveryRefreshInterval)
+	log.Infof("RateLimit                = %d", config.RateLimit)
+	log.Infof("SizeLimit                = %d", config.SizeLimit)
+	log.Infof("TCPKeepAlive             = %s", config.TCPKeepAlive)
+	log.Infof("TCPTimeout               = %s", config.TCPTimeout)
+
 	var baseWriter io.Writer
 	if len(config.DiscoveryServiceName) > 0 {
 		dialer := &net.Dialer{

--- a/xnet/writer.go
+++ b/xnet/writer.go
@@ -50,6 +50,7 @@ func (r *roundRobinWriter) Write(byte []byte) (int, error) {
 
 	select {
 	case newInstances := <-r.provider:
+		log.WithField("instances", newInstances).Info("Received new instances for RoundRobinWriter")
 		r.updateInstances(newInstances)
 		return r.write(byte)
 	default:


### PR DESCRIPTION
We need a more detailed logging for service log scraping because in the current situation it is sometimes impossible to say if everything is working properly.