### PR TITLE
Simplify Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,21 +2,12 @@ language: go
 go:
   - 1.9.x
 
-stages:
-  - name: test
-  - name: release
-
-jobs:
-  include:
-    - stage: test
-      script: make travis-ci
-    - stage: release
-      script: make release
-      deploy:
-        provider: releases
-        api_key:
-          secure: OxoxKpT3pTj5JjX2Pyfs/69RRzJ+uMwErvLYKCc7UwFvG3plag/qcJgawMLmqPg/xQ1KHeo8cdkIvbJkDRLH09e15YX3xNDCB2a/REGxqMs8iMBO7cWPWVYaNn925g1ffYEKR59csNib1ugkBRszeLhvCuvFG48NaSOU2fJyUdhbruh5xWrE8cJ6xRvUK1bwqMt4n5jPsHP4KlfRp3l3Jy/iDYogwnXanFSNGkZ6qPBYnY4I1b31T1podQtNjUKI5yKvd/Op3LoBu3z9EdhDpOykzs08LspcLo09Hn2c1RPilxmDwlfSni9EWIIMCgjFARiuXyxcyMzs6v9qf+WzBC7AnHy/KPIXfXIoSSDjV5oNgHIkvWdRKTGc3G4i0YmoxNx+ll4C71LMUT2t4X1zGMBA+E07Qioaq0dtXDemyQH51eiD0GpPk+35cK97pNY/CtdUNfJlerRa8wIxjk1yiFE+8K1vePXiA5xsDMiyIAQcv44W487+JEV29NnOnFoRU6PXMtQits+PWvn0BaJvCtQmodX9zQYkREy+h8RNST+IHJWi5SgSHqC8fmTbXi1iuGLq5kpR3TZvCrY52WZh/eWc7cyWTpZR6cJAX7OZcJguZRGPI4A740rCucnqkiyNltDPeArpkSnNIbY/go3XgtttsVycHjtYm8XhAJpo0A4=
-        skip_cleanup: true
-        file: target/executor-linux-amd64.zip
-        on:
-          tags: true
+script: make travis-ci
+deploy:
+  provider: releases
+  api_key:
+    secure: OxoxKpT3pTj5JjX2Pyfs/69RRzJ+uMwErvLYKCc7UwFvG3plag/qcJgawMLmqPg/xQ1KHeo8cdkIvbJkDRLH09e15YX3xNDCB2a/REGxqMs8iMBO7cWPWVYaNn925g1ffYEKR59csNib1ugkBRszeLhvCuvFG48NaSOU2fJyUdhbruh5xWrE8cJ6xRvUK1bwqMt4n5jPsHP4KlfRp3l3Jy/iDYogwnXanFSNGkZ6qPBYnY4I1b31T1podQtNjUKI5yKvd/Op3LoBu3z9EdhDpOykzs08LspcLo09Hn2c1RPilxmDwlfSni9EWIIMCgjFARiuXyxcyMzs6v9qf+WzBC7AnHy/KPIXfXIoSSDjV5oNgHIkvWdRKTGc3G4i0YmoxNx+ll4C71LMUT2t4X1zGMBA+E07Qioaq0dtXDemyQH51eiD0GpPk+35cK97pNY/CtdUNfJlerRa8wIxjk1yiFE+8K1vePXiA5xsDMiyIAQcv44W487+JEV29NnOnFoRU6PXMtQits+PWvn0BaJvCtQmodX9zQYkREy+h8RNST+IHJWi5SgSHqC8fmTbXi1iuGLq5kpR3TZvCrY52WZh/eWc7cyWTpZR6cJAX7OZcJguZRGPI4A740rCucnqkiyNltDPeArpkSnNIbY/go3XgtttsVycHjtYm8XhAJpo0A4=
+  skip_cleanup: true
+  file: target/executor-linux-amd64.zip
+  on:
+    tags: true

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ COVERAGEDIR := $(BUILD_FOLDER)/test-results
 CURRENT_DIR = $(shell pwd)
 PATH := $(CURRENT_DIR)/bin:$(PATH)
 
-.PHONY: clean test all build release deps lint lint-deps \
+.PHONY: clean test all build package deps lint lint-deps \
 		generate-source generate-source-deps
 
 all: lint test build
@@ -44,7 +44,7 @@ lint-deps:
 	@which gometalinter.v2 > /dev/null || \
 		(go get -u -v gopkg.in/alecthomas/gometalinter.v2 && gometalinter.v2 --install)
 
-release: clean build
+package: build
 	zip -j $(BUILD_FOLDER)/executor-linux-amd64.zip $(BUILD_FOLDER)/executor
 	chmod 0755 $(BUILD_FOLDER)/executor-linux-amd64.zip
 	chmod 0777 $(BUILD_FOLDER)
@@ -70,4 +70,4 @@ test-deps:
 	@which goveralls > /dev/null || \
 		(go get github.com/mattn/goveralls)
 
-travis-ci: lint build coveralls
+travis-ci: lint build coveralls package


### PR DESCRIPTION
We do not need two separate stages for release and testing. We can always make a release build and only limit deploy to tagged commits.