### PR TITLE
Fix: Add hooks env to command.

### DIFF
--- a/command.go
+++ b/command.go
@@ -137,7 +137,7 @@ func NewCommand(commandInfo mesos.CommandInfo, env []string, options ...func(*ex
 	//		similar to how POSIX exec families launch processes (i.e.,
 	//		execlp(value, arguments(0), arguments(1), ...)).
 	cmd := exec.Command("sh", "-c", commandInfo.GetValue()) // #nosec
-	cmd.Env = envWithoutExecutorConfig()
+	cmd.Env = append(envWithoutExecutorConfig(), env...)
 	for _, option := range options {
 		if err := option(cmd); err != nil {
 			return nil, fmt.Errorf("invalid config option: %s", err)

--- a/command_test.go
+++ b/command_test.go
@@ -21,7 +21,7 @@ func TestIfNewCancellableCommandReturnsCommandWithoutExecutorEnv(t *testing.T) {
 	defer os.Unsetenv("_ALLEGRO_EXECUTOR_")
 
 	commandInfo := newCommandInfo("./sleep 100", "ignored", false, []string{"ignored"})
-	command, err := NewCommand(commandInfo, nil)
+	command, err := NewCommand(commandInfo, []string{"ALLEGRO_EXECUTOR_NOT_REMOVED=y", "SOME_ENV=x"})
 	cmd := command.(*cancellableCommand).cmd
 
 	assert.NoError(t, err)
@@ -30,16 +30,17 @@ func TestIfNewCancellableCommandReturnsCommandWithoutExecutorEnv(t *testing.T) {
 	assert.True(t, cmd.SysProcAttr.Setpgid, "should have pgid flag set to true")
 
 	assert.NotContains(t, cmd.Env, "ALLEGRO_EXECUTOR_TEST_1=x")
-	assert.Contains(t, cmd.Env, "allegro_executor_TEST_2=y")
-	assert.Contains(t, cmd.Env, "TEST=z")
-	assert.Contains(t, cmd.Env, "_ALLEGRO_EXECUTOR_=0")
+
+	for _, e := range []string{"allegro_executor_TEST_2=y", "TEST=z", "_ALLEGRO_EXECUTOR_=0", "ALLEGRO_EXECUTOR_NOT_REMOVED=y", "SOME_ENV=x"} {
+		assert.Contains(t, cmd.Env, e)
+	}
 }
 
 func newCommandInfo(command, user string, shell bool, args []string) mesos.CommandInfo {
 	return mesos.CommandInfo{
-		Shell:       &shell,
-		Value:       &command,
-		Arguments:   args,
-		User:        &user,
+		Shell:     &shell,
+		Value:     &command,
+		Arguments: args,
+		User:      &user,
 	}
 }


### PR DESCRIPTION
Previous commit removes env with executor configs.
By accident it also removes (or not add) env generated by hook.