### PR TITLE
Add value filter to JSON log scraper

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -408,7 +408,8 @@ func (e *Executor) createOptionsForLogstashServiceLogScrapping(taskInfo mesos.Ta
 	for _, ignoredKey := range e.config.ServicelogIgnoreKeys {
 		values = append(values, []byte(ignoredKey))
 	}
-	scr := &scraper.JSON{}
+	filter := scraper.ValueFilter{Values: values}
+	scr := &scraper.JSON{KeyFilter: filter}
 	apr, err := appender.LogstashAppenderFromEnv()
 	if err != nil {
 		return nil, fmt.Errorf("cannot configure service log scraping: %s", err)

--- a/servicelog/scraper/json.go
+++ b/servicelog/scraper/json.go
@@ -12,6 +12,7 @@ import (
 
 // JSON is a scraper for logs represented as JSON objects.
 type JSON struct {
+	KeyFilter Filter
 }
 
 // StartScraping starts scraping logs in JSON format from given reader and sends
@@ -27,6 +28,13 @@ func (j *JSON) StartScraping(reader io.Reader) <-chan servicelog.Entry {
 			if err := json.Unmarshal(scanner.Bytes(), &logEntry); err != nil {
 				log.WithError(err).Warn("Unable to unmarshal log entry - skipping line")
 				continue
+			}
+			if j.KeyFilter != nil {
+				for key := range logEntry {
+					if j.KeyFilter.Match([]byte(key)) {
+						delete(logEntry, key)
+					}
+				}
 			}
 			logEntries <- logEntry
 		}


### PR DESCRIPTION
Previous default scraper allowed to ignore selected fields in logs. This commit adds such functionality to new default scraper (JSON).