### PR TITLE
Fix VaaS registration regression

### DIFF
--- a/hook/vaas/hook.go
+++ b/hook/vaas/hook.go
@@ -114,8 +114,7 @@ func (sh *Hook) RegisterBackend(taskInfo mesosutils.TaskInfo) error {
 	}
 	_, err = sh.client.AddBackend(backend)
 	if err != nil {
-		return fmt.Errorf("unable to register backend with VaaS, %s: %d, reason: %s",
-			vaasBackendIDKey, *sh.backendID, err)
+		return fmt.Errorf("unable to register backend with VaaS, %s", err)
 	}
 	sh.backendID = backend.ID
 


### PR DESCRIPTION
When VaaS registration request was unsuccessful, executor crashed.
This happened because *sh.backendID was nil pointer when referenced, it
turned out, it is set only after correct response from server.