### PR TITLE
Allow disabling hooks.

### DIFF
--- a/hook/consul/hook.go
+++ b/hook/consul/hook.go
@@ -41,6 +41,8 @@ type Hook struct {
 
 // Config is Consul hook configuration settable from environment
 type Config struct {
+	// Enabled is a flag to control whether hook should be used
+	Enabled bool `default:"true" envconfig:"consul_hook_enabled"`
 	// Consul ACL Token
 	ConsulToken string `default:"" envconfig:"consul_token"`
 	// ConsulGlobalTag is a tag added to every service registered in Consul.
@@ -213,6 +215,9 @@ func generateURL(path string, port int) string {
 
 // NewHook creates new Consul hook that is responsible for graceful Consul deregistration.
 func NewHook(cfg Config) (hook.Hook, error) {
+	if !cfg.Enabled {
+		return hook.NoopHook{}, nil
+	}
 	config := api.DefaultConfig()
 	config.Token = cfg.ConsulToken
 	client, err := api.NewClient(config)

--- a/hook/consul/hook_test.go
+++ b/hook/consul/hook_test.go
@@ -286,7 +286,7 @@ func TestIfGeneratesCorrectNameIfConsulLabelEmpty(t *testing.T) {
 }
 
 func TestIfNoErrorOnUnsupportedEvent(t *testing.T) {
-	h, err := NewHook(Config{})
+	h, err := NewHook(Config{Enabled: true})
 
 	require.NoError(t, err)
 
@@ -344,6 +344,13 @@ func TestIfErrorHandledOnNoConsul(t *testing.T) {
 
 	require.Error(t, err)
 	require.Len(t, h.serviceInstances, 0)
+}
+
+func TestIfNewHookCreatesNoopHookWhenHookDisabled(t *testing.T) {
+	h, err := NewHook(Config{Enabled: false})
+
+	require.NoError(t, err)
+	require.IsType(t, hook.NoopHook{}, h)
 }
 
 func stopConsul(server *testutil.TestServer) {

--- a/hook/hook.go
+++ b/hook/hook.go
@@ -19,6 +19,15 @@ const (
 	BeforeTerminateEvent
 )
 
+// NoopHook is a hook that ignores all events
+type NoopHook struct {
+}
+
+// HandleEvent ignores all events
+func (noop NoopHook) HandleEvent(event Event) (Env, error) {
+	return nil, nil
+}
+
 // Event is a container type for various event specific data.
 type Event struct {
 	Type     EventType

--- a/hook/vaas/hook.go
+++ b/hook/vaas/hook.go
@@ -33,6 +33,8 @@ type Hook struct {
 
 // Config is Varnish configuration settable from environment
 type Config struct {
+	// Enabled is a flag to control whether hook should be used
+	Enabled bool `default:"true" envconfig:"vaas_hook_enabled"`
 	// Varnish as a Service API url
 	VaasAPIHost string `default:"" envconfig:"vaas_host"`
 	// Varnish as a Service username
@@ -161,7 +163,10 @@ func (sh *Hook) HandleEvent(event hook.Event) (hook.Env, error) {
 }
 
 // NewHook returns new instance of Hook.
-func NewHook(cfg Config) (*Hook, error) {
+func NewHook(cfg Config) (hook.Hook, error) {
+	if !cfg.Enabled {
+		return hook.NoopHook{}, nil
+	}
 	return &Hook{
 		client: NewClient(
 			cfg.VaasAPIHost,

--- a/hook/vaas/hook_test.go
+++ b/hook/vaas/hook_test.go
@@ -259,7 +259,7 @@ func TestDoNotRegisterVaasBackendWhenDirectorNotSet(t *testing.T) {
 }
 
 func TestIfNoErrorOnUnsupportedEvent(t *testing.T) {
-	h, err := NewHook(Config{})
+	h, err := NewHook(Config{Enabled: true})
 
 	require.NoError(t, err)
 
@@ -268,4 +268,11 @@ func TestIfNoErrorOnUnsupportedEvent(t *testing.T) {
 	})
 
 	require.NoError(t, err)
+}
+
+func TestIfNewHookCreatesNoopHookWhenHookDisabled(t *testing.T) {
+	h, err := NewHook(Config{Enabled: false})
+
+	require.NoError(t, err)
+	assert.IsType(t, hook.NoopHook{}, h)
 }


### PR DESCRIPTION
Added configuration option to disable specific hooks.
When hook is diabled, trying to create it from configration
results in creation of `NoopHook` ignoring all events.

Fixes: #100