### PR TITLE
Fix deadlock on multiple kill events

### DIFF
--- a/executor_test.go
+++ b/executor_test.go
@@ -363,7 +363,9 @@ func TestCertificateCheckScheduleTaskKillBeforeCertificateExpires(t *testing.T) 
 func TestIfNotPanicsWhenKillWithoutLaunch(t *testing.T) {
 	stateUpdater := new(mockUpdater)
 	stateUpdater.On("UpdateWithOptions",
-		mock.AnythingOfType("mesos.TaskID"),
+		mock.MatchedBy(func(taskID mesos.TaskID) bool {
+			return taskID.GetValue() == "taskID"
+		}),
 		mesos.TASK_KILLED,
 		mock.AnythingOfType("state.OptionalInfo")).Once()
 	events := make(chan Event, 1)
@@ -375,7 +377,7 @@ func TestIfNotPanicsWhenKillWithoutLaunch(t *testing.T) {
 	}
 
 	assert.NotPanics(t, func() {
-		events <- Event{Type: Kill}
+		events <- Event{Type: Kill, kill: executor.Event_Kill{TaskID: mesos.TaskID{Value: "taskID"}}}
 		exec.taskEventLoop()
 		stateUpdater.AssertExpectations(t)
 	})

--- a/gometalinter.json
+++ b/gometalinter.json
@@ -1,7 +1,7 @@
 {
   "Aggregate": true,
   "Concurrency": 2,
-  "Cyclo": 14,
+  "Cyclo": 15,
   "Deadline": "300s",
   "DisableAll": true,
   "Enable": [


### PR DESCRIPTION
After first kill event received from Mesos agent executor is stopping the goroutine that is responsible for listening to events channel. This commit changes the events channel to be buffered so sending second event will not lock the whole executor process. Also the kill logic is now based on task ID received from Mesos agent, so if executor missed the launch event it can still return valid TaskStatus messages.