### PR TITLE
Fix JSON service log scraping with too long tokens

### DIFF
--- a/servicelog/scraper/json_test.go
+++ b/servicelog/scraper/json_test.go
@@ -36,7 +36,7 @@ func TestIfFiltersKeysFromScrapedJSONs(t *testing.T) {
 	assert.Len(t, entry, 1)
 }
 
-func TestIfWrapsInDefualtValuesInvalidLogEntriesWhenEnabled(t *testing.T) {
+func TestIfWrapsInDefaultValuesInvalidLogEntriesWhenEnabled(t *testing.T) {
 	reader, writer := io.Pipe()
 	scraper := JSON{
 		ScrapUnmarshallableLogs: true,
@@ -50,4 +50,24 @@ func TestIfWrapsInDefualtValuesInvalidLogEntriesWhenEnabled(t *testing.T) {
 	assert.Equal(t, "ERROR my invalid format", entry["msg"])
 	assert.Equal(t, "invalid-format", entry["logger"])
 	assert.Equal(t, "INFO", entry["level"])
+}
+
+func TestIfNotFailsWithTooLongTokens(t *testing.T) {
+	reader, writer := io.Pipe()
+	scraper := JSON{
+		ScrapUnmarshallableLogs: true,
+	}
+
+	entries := scraper.StartScraping(reader)
+
+	// send to long token (size > 1MB)
+	go writer.Write(make([]byte, 1024*1024*5, 1024*1024*5))
+	// send valid log, it should be scraped
+	go writer.Write([]byte("{\"a\":\"b\", \"c\":\"d\"}\n"))
+
+	entry := <-entries
+
+	assert.Equal(t, "b", entry["a"])
+	assert.Equal(t, "d", entry["c"])
+	assert.Len(t, entry, 2)
 }


### PR DESCRIPTION
When JSON service log scraper receives too long token it should not stop the service log scraping - it should just recreate the scanner.