### PR TITLE
Fix VaaS credentials leakage

### DIFF
--- a/hook/vaas/client.go
+++ b/hook/vaas/client.go
@@ -240,7 +240,7 @@ func (c *defaultClient) do(request *http.Request) (*http.Response, error) {
 			message = string(rawResponse)
 		}
 		return response, fmt.Errorf("VaaS API error at %s (HTTP %d): %s",
-			request.URL, response.StatusCode, message)
+			request.URL.Path, response.StatusCode, message)
 	}
 
 	return response, nil


### PR DESCRIPTION
Fix VaaS credentials leakage in executor logs by logging only the request path (credentials are in query string).