### PR TITLE
Add optional buffer to JSON scraper

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -460,6 +460,7 @@ func (e *Executor) createOptionsForLogstashServiceLogScrapping(taskInfo mesos.Ta
 	filter := scraper.ValueFilter{Values: values}
 	scr := &scraper.JSON{
 		KeyFilter:               filter,
+		BufferSize:              2000,
 		ScrapUnmarshallableLogs: utilTaskInfo.GetLabelValue("log-scraping-all") != "",
 	}
 	apr, err := appender.LogstashAppenderFromEnv()


### PR DESCRIPTION
Scraping logs from the stdout may be sometimes blocking for the application that is sending logs because executor can not keep up with sending logs due to a temporary network delays. The executor should drop the logs if there is a risk that the writes to stdout will become blocking.