### PR TITLE
Deal with oversized messages

### DIFF
--- a/servicelog/appender/logstash.go
+++ b/servicelog/appender/logstash.go
@@ -83,6 +83,7 @@ func (l *logstash) sendEntry(entry servicelog.Entry) error {
 	if err != nil {
 		if err == xio.ErrSizeLimitExceeded {
 			l.droppedBecauseOfSize.Inc(1)
+			log.Infof("message dropped because of size: %s", string(bytes))
 			return nil // returning this error will spam stdout with errors
 		}
 		if err == xio.ErrRateLimitExceeded {


### PR DESCRIPTION
When message is dropped due its size owner of running service cannot get any info what generated this message. This change allows sending oversized messages to logstash with a parallel increase of droppedBecauseOfSize counter.

Other idea is to print to stdout oversized messages but this can completely fill the sandbox disk space.