### PR TITLE
Add marathon-task tag to registered service

### DIFF
--- a/hook/consul/hook.go
+++ b/hook/consul/hook.go
@@ -107,8 +107,10 @@ func (h *Hook) RegisterIntoConsul(taskInfo mesosutils.TaskInfo) error {
 		// it registers the service
 		// See: https://github.com/allegro/marathon-consul/blob/v1.1.0/consul/consul.go#L299-L301
 		consulServiceID := fmt.Sprintf("%s_%s_%d", taskID, portServiceName, port.GetNumber())
+		marathonTaskTag := fmt.Sprintf("marathon-task:%s", taskID)
 		portTags := mesosutils.GetLabelKeysByValue(port.GetLabels().GetLabels(), consulTagValue)
 		portTags = append(portTags, globalTags...)
+		portTags = append(portTags, marathonTaskTag)
 		log.Infof("Adding service ID %q to deregister before termination", consulServiceID)
 		instancesToRegister = append(instancesToRegister, instance{
 			consulServiceName: portServiceName,

--- a/hook/consul/hook_test.go
+++ b/hook/consul/hook_test.go
@@ -193,13 +193,13 @@ func TestIfUsesPortLabelsForRegistration(t *testing.T) {
 		consulServiceName: "consulName",
 		consulServiceID:   createServiceID(taskID, consulName, 666),
 		port:              666,
-		tags:              []string{"hystrix", "metrics", "extras", "marathon"},
+		tags:              []string{"hystrix", "metrics", "extras", "marathon", "marathon-task:taskID"},
 	}
 	expectedService2 := instance{
 		consulServiceName: "consulName-secured",
 		consulServiceID:   createServiceID(taskID, consulNameSecond, 997),
 		port:              997,
-		tags:              []string{"metrics", "extras", "marathon"},
+		tags:              []string{"metrics", "extras", "marathon", "marathon-task:taskID"},
 	}
 
 	// Create a test Consul server
@@ -375,8 +375,8 @@ func TestIfPlaceholdersAreResolved(t *testing.T) {
 		{Number: 877, Name: &servicePortName},
 	})
 
-	expectedServiceTags := []string{"marathon", "service-port:877", "admin-port:655", "{port:unknown} is not replaced"}
-	expectedAdminTags := []string{"marathon", "admin", "service-port:877"}
+	expectedServiceTags := []string{"marathon", "service-port:877", "admin-port:655", "{port:unknown} is not replaced", "marathon-task:taskId"}
+	expectedAdminTags := []string{"marathon", "admin", "service-port:877", "marathon-task:taskId"}
 
 	h := &Hook{config: Config{ConsulGlobalTag: "marathon"}, client: client}
 


### PR DESCRIPTION
Mesos-executor should register services in the same way as marathon-consul so that the information registered by marathon-consul can not be overwritten by "slow" mesos-executor event. 