### PR TITLE
Change KillTree to no longer send SIGCONT after SIGKILL

### DIFF
--- a/os/kill.go
+++ b/os/kill.go
@@ -62,7 +62,11 @@ func getAllChildren(proc *process.Process) []*process.Process {
 // SIGCONT to prevent processes from forking during termination, so we will not
 // have orphaned processes after.
 func wrapWithStopAndCont(signal syscall.Signal, pgids []int) error {
-	signals := []syscall.Signal{syscall.SIGSTOP, signal, syscall.SIGCONT}
+	signals := []syscall.Signal{syscall.SIGSTOP, signal}
+	if signal != syscall.SIGKILL { // no point in sending any signal after SIGKILL
+		signals = append(signals, syscall.SIGCONT)
+	}
+
 	for _, currentSignal := range signals {
 		if err := sendSignalToProcessGroups(currentSignal, pgids); err != nil {
 			return err


### PR DESCRIPTION
Sending any signal after SIGKILL doesn't achieve anything. Only creates errors in logs and causes KillTree tests to sometimes fail.