### PR TITLE
Omit SIGTERM to certain processes during stop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - 1.10.x
+  - 1.13.1
 
 script: 
   - make

--- a/README.md
+++ b/README.md
@@ -171,8 +171,6 @@ vagrant@localhost:~$ sudo supervisorctl tail -f consul
 so service process may be still running when executor finishes.
 To clean up executor and launched tasks properly use [pid isolator][10].
 
-Requires `pgrep -g` to be available on the machine.
-
 ## Contributing
 
 See [CONTRIBUTING](CONTRIBUTING.md) for more details and code of conduct. 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ It is performed in the following steps:
 
 Executor can be configured to exclude certain processes from SIGTERM signal. Provide
 process names to exclude in `ALLEGRO_EXECUTOR_SIGTERM_EXCLUDE_PROCESSES` environment variable
-as a comma-separated string.
+as a comma-separated string. This feature requires `pgrep -g` to be available on the machine.
 
 ## Log scraping
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ It is performed in the following steps:
 3. Wait `KillPolicyGracePeriod` (can be overridden with Task Kill Policy Grace Period).
 4. Sent SIGKILL to process tree.
 
+Executor can be configured to exclude certain processes from SIGTERM signal. Provide
+process names to exclude in `ALLEGRO_EXECUTOR_SIGTERM_EXCLUDE_PROCESSES` environment variable
+as a comma-separated string.
+
 ## Log scraping
 
 By default executor forwards service stdout/stderr to its own standard streams.
@@ -166,6 +170,8 @@ vagrant@localhost:~$ sudo supervisorctl tail -f consul
 1. Executor may not send a SIGKILL to process tree after grace period,
 so service process may be still running when executor finishes.
 To clean up executor and launched tasks properly use [pid isolator][10].
+
+Requires `pgrep -g` to be available on the machine.
 
 ## Contributing
 

--- a/command.go
+++ b/command.go
@@ -108,7 +108,7 @@ func (c *cancellableCommand) Stop(gracePeriod time.Duration) {
 		return
 	}
 	c.killing = true
-	err := osutil.KillTree(syscall.SIGTERM, int32(c.cmd.Process.Pid))
+	err := osutil.KillTreeWithExcludes(syscall.SIGTERM, int32(c.cmd.Process.Pid))
 	if err != nil {
 		log.WithError(err).Errorf("There was a problem with sending %s to %d children", syscall.SIGTERM, c.cmd.Process.Pid)
 		return

--- a/os/kill.go
+++ b/os/kill.go
@@ -162,11 +162,8 @@ func excludeProcesses(pids []int, processesToExclude []string) ([]int, error) {
 
 		name, err := proc.Name()
 		if err != nil {
-			log.Infof("Could not get process name of %d, continuing", pid)
-			continue
-		}
-
-		if isExcluded(name, processesToExclude) {
+			log.Infof("Could not get process name of %d, will not exclude it from kill", pid)
+		} else if isExcluded(name, processesToExclude) {
 			log.Infof("Excluding process %s with pid %d from kill", name, pid)
 			continue
 		}

--- a/os/kill.go
+++ b/os/kill.go
@@ -85,7 +85,6 @@ func sendSignalsToProcessGroups(signals []syscall.Signal, pgids []int) error {
 			err := syscall.Kill(-pgid, signal)
 			if err != nil {
 				log.Infof("Error sending signal to pgid %d: %s", pgid, err)
-				return err
 			}
 		}
 	}

--- a/os/kill.go
+++ b/os/kill.go
@@ -100,6 +100,10 @@ func sendSignalsToProcessGroups(signals []syscall.Signal, pgids []int) error {
 func KillTreeWithExcludes(signal syscall.Signal, pid int32, processesToExclude []string) error {
 	log.Infof("Will send signal %s to tree starting from %d", signal.String(), pid)
 
+	if len(processesToExclude) == 0 {
+		return KillTree(signal, pid)
+	}
+
 	pgids, err := getProcessGroupsInTree(pid)
 	if err != nil {
 		return err

--- a/os/kill.go
+++ b/os/kill.go
@@ -190,7 +190,6 @@ func sendSignalsToProcesses(signals []syscall.Signal, pids []int) error {
 			err := syscall.Kill(pid, signal)
 			if err != nil {
 				log.Infof("Error sending signal to pid %d: %s", pid, err)
-				return err
 			}
 		}
 	}

--- a/os/kill.go
+++ b/os/kill.go
@@ -22,7 +22,7 @@ func KillTree(signal syscall.Signal, pid int32) error {
 		return err
 	}
 
-	signals := wrapWithStopAndCont(signal, pgids)
+	signals := wrapWithStopAndCont(signal)
 	return sendSignalsToProcessGroups(signals, pgids)
 }
 
@@ -74,7 +74,7 @@ func getAllChildren(proc *process.Process) []*process.Process {
 // wrapWithStopAndCont wraps original process tree signal sending with SIGSTOP and
 // SIGCONT to prevent processes from forking during termination, so we will not
 // have orphaned processes after.
-func wrapWithStopAndCont(signal syscall.Signal, pgids []int) []syscall.Signal {
+func wrapWithStopAndCont(signal syscall.Signal) []syscall.Signal {
 	signals := []syscall.Signal{syscall.SIGSTOP, signal}
 	if signal != syscall.SIGKILL { // no point in sending any signal after SIGKILL
 		signals = append(signals, syscall.SIGCONT)
@@ -119,7 +119,7 @@ func KillTreeWithExcludes(signal syscall.Signal, pid int32, processesToExclude [
 		return err
 	}
 
-	signals := wrapWithStopAndCont(signal, pgids)
+	signals := wrapWithStopAndCont(signal)
 	return sendSignalsToProcesses(signals, pids)
 }
 

--- a/os/kill_test.go
+++ b/os/kill_test.go
@@ -3,8 +3,10 @@
 package os
 
 import (
+	"errors"
 	"github.com/shirou/gopsutil/process"
 	"os/exec"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -46,7 +48,7 @@ func TestKillTreeWithExcludes_SimpleTree(t *testing.T) {
 	cmd := startTestProcesses(t, "testdata/fork.sh")
 	cmdPids := addAllChildrenPids(cmd.Process.Pid)
 
-	killErr := KillTreeWithExcludes(syscall.SIGTERM, int32(cmd.Process.Pid))
+	killErr := KillTreeWithExcludes(syscall.SIGTERM, int32(cmd.Process.Pid), []string{})
 	require.NoError(t, killErr)
 	waitToDie(cmd)
 
@@ -59,11 +61,56 @@ func TestKillTreeWithExcludes_ComplexTree(t *testing.T) {
 	cmd := startTestProcesses(t, "testdata/fork2.sh")
 	cmdPids := addAllChildrenPids(cmd.Process.Pid)
 
-	killErr := KillTreeWithExcludes(syscall.SIGTERM, int32(cmd.Process.Pid))
+	killErr := KillTreeWithExcludes(syscall.SIGTERM, int32(cmd.Process.Pid), []string{})
 	require.NoError(t, killErr)
 	waitToDie(cmd)
 
 	assertProcessesDontExist(t, cmdPids)
+	assertFinishedWithinTimeLimit(t, startTime)
+}
+
+func TestKillTreeWithExcludes_ComplexTreeExcludingProcessThatDoesntExist(t *testing.T) {
+	startTime := time.Now()
+	cmd := startTestProcesses(t, "testdata/fork2.sh")
+	cmdPids := addAllChildrenPids(cmd.Process.Pid)
+
+	killErr := KillTreeWithExcludes(syscall.SIGTERM, int32(cmd.Process.Pid), []string{"non-existing"})
+	require.NoError(t, killErr)
+	waitToDie(cmd)
+
+	assertProcessesDontExist(t, cmdPids)
+	assertFinishedWithinTimeLimit(t, startTime)
+}
+
+func TestKillTreeWithExcludes_ComplexTreeExcludingOneExistingProcess(t *testing.T) {
+	startTime := time.Now()
+	cmd := startTestProcesses(t, "testdata/fork2.sh")
+	cmdPids := addAllChildrenPids(cmd.Process.Pid)
+	excluded, findErr := findPidWithProcessName("python", cmdPids)
+	require.NoError(t, findErr)
+
+	killErr := KillTreeWithExcludes(syscall.SIGTERM, int32(cmd.Process.Pid), []string{"python"})
+	require.NoError(t, killErr)
+	waitToDie(cmd)
+
+	assertProcessesDontExist(t, removePid(cmdPids, excluded))
+	assertProcessExists(t, excluded)
+	assertFinishedWithinTimeLimit(t, startTime)
+}
+
+func TestKillTreeWithExcludes_ComplexTreeExcludingOneExistingProcessAndOneNonExisting(t *testing.T) {
+	startTime := time.Now()
+	cmd := startTestProcesses(t, "testdata/fork2.sh")
+	cmdPids := addAllChildrenPids(cmd.Process.Pid)
+	excluded, findErr := findPidWithProcessName("python", cmdPids)
+	require.NoError(t, findErr)
+
+	killErr := KillTreeWithExcludes(syscall.SIGTERM, int32(cmd.Process.Pid), []string{"python","non-existing"})
+	require.NoError(t, killErr)
+	waitToDie(cmd)
+
+	assertProcessesDontExist(t, removePid(cmdPids, excluded))
+	assertProcessExists(t, excluded)
 	assertFinishedWithinTimeLimit(t, startTime)
 }
 
@@ -72,7 +119,7 @@ func startTestProcesses(t *testing.T, commandName string) *exec.Cmd {
 	err := cmd.Start()
 	require.NoError(t, err)
 
-	time.Sleep(200 * time.Millisecond) // give time for processes to spawn
+	time.Sleep(100 * time.Millisecond) // give time for processes to spawn
 	return cmd
 }
 
@@ -86,15 +133,46 @@ func addAllChildrenPids(rootPid int) []int {
 	return pids
 }
 
+func findPidWithProcessName(searchedName string, pids []int) (int, error) {
+	for _, pid := range pids {
+		proc, err := process.NewProcess(int32(pid))
+		if err != nil {
+			return -1, err
+		}
+		name, err := proc.Name()
+		if err != nil {
+			return -1, err
+		}
+		if strings.ToLower(name) == searchedName {
+			return pid, nil
+		}
+	}
+	return -1, errors.New("process not found")
+}
+
 func waitToDie(cmd *exec.Cmd) {
-	time.Sleep(200 * time.Millisecond) // give time for children to die
+	time.Sleep(100 * time.Millisecond) // give time for children to die
 	_, _ = cmd.Process.Wait()
+}
+
+func removePid(pids []int, toRemove int) []int {
+	var result []int
+	for _, pid := range pids {
+		if pid != toRemove {
+			result = append(result, pid)
+		}
+	}
+	return result
 }
 
 func assertProcessesDontExist(t *testing.T, cmdPids []int) {
 	for _, pid := range cmdPids {
 		assert.False(t, processExists(pid), "process %d still exists", pid)
 	}
+}
+
+func assertProcessExists(t *testing.T, pid int) {
+	assert.True(t, processExists(pid), "process %d does not exist", pid)
 }
 
 // Test processes finish successfully after TIME_LIMIT. Only if the test finishes earlier

--- a/os/kill_test.go
+++ b/os/kill_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const TIME_LIMIT = 5 * time.Second // equal to sleep time in test scripts
+const TIME_LIMIT = 3 * time.Second // equal to sleep time in test scripts
 
 func TestKillTree_SimpleTreeTree(t *testing.T) {
 	startTime := time.Now()

--- a/os/kill_test.go
+++ b/os/kill_test.go
@@ -3,6 +3,7 @@
 package os
 
 import (
+	"github.com/shirou/gopsutil/process"
 	"os/exec"
 	"syscall"
 	"testing"
@@ -14,18 +15,86 @@ import (
 
 const TIME_LIMIT = 5 * time.Second // equal to sleep time in test scripts
 
-func TestSendingSignalToTree(t *testing.T) {
+func TestKillTree_SimpleTreeTree(t *testing.T) {
 	startTime := time.Now()
-	cmd := exec.Command("testdata/fork.sh")
-	err := cmd.Start()
-	require.NoError(t, err)
+	cmd := startTestProcesses(t, "testdata/fork.sh")
+	cmdPids := addAllChildrenPids(cmd.Process.Pid)
 
 	killErr := KillTree(syscall.SIGKILL, int32(cmd.Process.Pid))
 	require.NoError(t, killErr)
-	_, _ = cmd.Process.Wait()
+	waitToDie(cmd)
 
-	assert.False(t, processExists(cmd.Process.Pid))
+	assertProcessesDontExist(t, cmdPids)
 	assertFinishedWithinTimeLimit(t, startTime)
+}
+
+func TestKillTree_ComplexTree(t *testing.T) {
+	startTime := time.Now()
+	cmd := startTestProcesses(t, "testdata/fork2.sh")
+	cmdPids := addAllChildrenPids(cmd.Process.Pid)
+
+	killErr := KillTree(syscall.SIGKILL, int32(cmd.Process.Pid))
+	require.NoError(t, killErr)
+	waitToDie(cmd)
+
+	assertProcessesDontExist(t, cmdPids)
+	assertFinishedWithinTimeLimit(t, startTime)
+}
+
+func TestKillTreeWithExcludes_SimpleTree(t *testing.T) {
+	startTime := time.Now()
+	cmd := startTestProcesses(t, "testdata/fork.sh")
+	cmdPids := addAllChildrenPids(cmd.Process.Pid)
+
+	killErr := KillTreeWithExcludes(syscall.SIGTERM, int32(cmd.Process.Pid))
+	require.NoError(t, killErr)
+	waitToDie(cmd)
+
+	assertProcessesDontExist(t, cmdPids)
+	assertFinishedWithinTimeLimit(t, startTime)
+}
+
+func TestKillTreeWithExcludes_ComplexTree(t *testing.T) {
+	startTime := time.Now()
+	cmd := startTestProcesses(t, "testdata/fork2.sh")
+	cmdPids := addAllChildrenPids(cmd.Process.Pid)
+
+	killErr := KillTreeWithExcludes(syscall.SIGTERM, int32(cmd.Process.Pid))
+	require.NoError(t, killErr)
+	waitToDie(cmd)
+
+	assertProcessesDontExist(t, cmdPids)
+	assertFinishedWithinTimeLimit(t, startTime)
+}
+
+func startTestProcesses(t *testing.T, commandName string) *exec.Cmd {
+	cmd := exec.Command(commandName)
+	err := cmd.Start()
+	require.NoError(t, err)
+
+	time.Sleep(200 * time.Millisecond) // give time for processes to spawn
+	return cmd
+}
+
+func addAllChildrenPids(rootPid int) []int {
+	newProcess, _ := process.NewProcess(int32(rootPid))
+	children := getAllChildren(newProcess)
+	pids := []int{rootPid}
+	for _, c := range children {
+		pids = append(pids, int(c.Pid))
+	}
+	return pids
+}
+
+func waitToDie(cmd *exec.Cmd) {
+	time.Sleep(200 * time.Millisecond) // give time for children to die
+	_, _ = cmd.Process.Wait()
+}
+
+func assertProcessesDontExist(t *testing.T, cmdPids []int) {
+	for _, pid := range cmdPids {
+		assert.False(t, processExists(pid), "process %d still exists", pid)
+	}
 }
 
 // Test processes finish successfully after TIME_LIMIT. Only if the test finishes earlier

--- a/os/testdata/fork.sh
+++ b/os/testdata/fork.sh
@@ -1,4 +1,8 @@
 #!/bin/sh
 
-set -m
-(sh -c "(sleep 3)") || true
+if command -v setsid 2>/dev/null; then
+    setsid sh -c "sleep 3"
+else  # osx
+    set -m
+    sh -c "sleep 3"
+fi

--- a/os/testdata/fork.sh
+++ b/os/testdata/fork.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 set -m
-(sh -c "(sleep 5)") || true
+(sh -c "(sleep 3)") || true

--- a/os/testdata/fork2.sh
+++ b/os/testdata/fork2.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -m
+sleep 5 &
+python -c "import time; time.sleep(5)" &
+(sh -c "(sleep 5)") || true

--- a/os/testdata/fork2.sh
+++ b/os/testdata/fork2.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
 set -m
-sleep 5 &
-python -c "import time; time.sleep(5)" &
-(sh -c "(sleep 5)") || true
+sleep 3 &
+python -c "import time; time.sleep(3)" &
+(sh -c "(sleep 3)") || true

--- a/os/testdata/fork2.sh
+++ b/os/testdata/fork2.sh
@@ -1,6 +1,12 @@
 #!/bin/sh
 
-set -m
-sleep 3 &
-python -c "import time; time.sleep(3)" &
-(sh -c "(sleep 3)") || true
+if command -v setsid 2>/dev/null; then
+    setsid sleep 3 &
+    setsid python -c "import time; time.sleep(3)" &
+    setsid sh -c "sleep 3"
+else  # osx
+    set -m
+    sleep 3 &
+    python -c "import time; time.sleep(3)" &
+    sh -c "sleep 3"
+fi


### PR DESCRIPTION
Allows to configure process names that will be excluded from the SIGTERM kill during stop. They will still be killed later, after grace period, with SIGKILL. 

Use-case: we want to delay sending SIGTERM to a certain process. By excluding this process from executor kills we can send SIGTERM on our own later by other means.

Configurable via `ALLEGRO_EXECUTOR_SIGTERM_EXCLUDE_PROCESSES` environment variable.