### PR TITLE
Remove cluster array from Directory struct, is no necessary

### DIFF
--- a/hook/vaas/client.go
+++ b/hook/vaas/client.go
@@ -54,7 +54,6 @@ type DCList struct {
 type Director struct {
 	ID          int      `json:"id,omitempty"`
 	Backends    []string `json:"backends,omitempty"`
-	Cluster     []string `json:"cluster,omitempty"`
 	Name        string   `json:"name,omitempty"`
 	ResourceURI string   `json:"resource_uri,omitempty"`
 }


### PR DESCRIPTION
You dont need cluster in directory struct because you dont use it.
We will change cluster api in vaas so after that nothing will be happened in executor. 