### PR TITLE
Wait with removing service instances

### DIFF
--- a/hook/consul/hook.go
+++ b/hook/consul/hook.go
@@ -180,7 +180,10 @@ func (h *Hook) DeregisterFromConsul(taskInfo mesosutils.TaskInfo) error {
 		}
 	}
 	h.serviceInstances = ghostInstances
-	time.Sleep(h.config.KeepServiceHealthyAfterDeregistrationTime)
+	if h.config.KeepServiceHealthyAfterDeregistrationTime > 0 {
+		log.Infof("Wait for %d after consul deregistration", h.config.KeepServiceHealthyAfterDeregistrationTime)
+		time.Sleep(h.config.KeepServiceHealthyAfterDeregistrationTime)
+	}
 	return nil
 }
 

--- a/hook/consul/hook.go
+++ b/hook/consul/hook.go
@@ -62,7 +62,7 @@ type Config struct {
 	InitialHealthCheckStatus string `default:"passing" envconfig:"initial_health_check_status"`
 	// Delay for changing service state to unhealthy after it's deregistration from consul
 	// It allows to minimize problems with instances propagation to different consul agents
-	KeepServiceHealthyAfterDeregistrationTime time.Duration `default:"5s" envconfig:"keep_service_healthy_after_deregistration_time"`
+	KeepServiceHealthyAfterDeregistrationTime time.Duration `default:"0s" envconfig:"keep_service_healthy_after_deregistration_time"`
 }
 
 // HandleEvent calls appropriate hook functions that correspond to supported
@@ -181,7 +181,7 @@ func (h *Hook) DeregisterFromConsul(taskInfo mesosutils.TaskInfo) error {
 	}
 	h.serviceInstances = ghostInstances
 	if h.config.KeepServiceHealthyAfterDeregistrationTime > 0 {
-		log.Infof("Wait for %d after consul deregistration", h.config.KeepServiceHealthyAfterDeregistrationTime)
+		log.Infof("Wait for %s after consul deregistration", h.config.KeepServiceHealthyAfterDeregistrationTime.String())
 		time.Sleep(h.config.KeepServiceHealthyAfterDeregistrationTime)
 	}
 	return nil

--- a/hook/consul/hook.go
+++ b/hook/consul/hook.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/consul/api"
 	log "github.com/sirupsen/logrus"
@@ -59,6 +60,9 @@ type Config struct {
 	// By default we assume service health was checked initially by marathon
 	// It will be set to passing.
 	InitialHealthCheckStatus string `default:"passing" envconfig:"initial_health_check_status"`
+	// Delay for changing service state to unhealthy after it's deregistration from consul
+	// It allows to minimize problems with instances propagation to different consul agents
+	KeepServiceHealthyAfterDeregistrationTime time.Duration `default:"5s" envconfig:"keep_service_healthy_after_deregistration_time"`
 }
 
 // HandleEvent calls appropriate hook functions that correspond to supported
@@ -176,7 +180,7 @@ func (h *Hook) DeregisterFromConsul(taskInfo mesosutils.TaskInfo) error {
 		}
 	}
 	h.serviceInstances = ghostInstances
-
+	time.Sleep(h.config.KeepServiceHealthyAfterDeregistrationTime)
 	return nil
 }
 


### PR DESCRIPTION
Currently after deregistering service from consul it's removed from marathon immediately. Unfortunately it takes some time to propagate information about service instance removal to all consul agents. Some consul agents can receive this information after removing service instance from marathon and they will try to invoke non existing service. To mitigate this problem we can set additional parametr for consul hook - keep_service_healthy_after_deregistration_time. It will make consul hook wait for specified delay after deregistering service from consul before it's removal from marathon. This will give some time required for updating all consul agents.